### PR TITLE
Removes double semicolons on import statements

### DIFF
--- a/diana/diana-core/src/main/java/org/jnosql/diana/reader/MapTypeReferenceReader.java
+++ b/diana/diana-core/src/main/java/org/jnosql/diana/reader/MapTypeReferenceReader.java
@@ -18,7 +18,7 @@ package org.jnosql.diana.reader;
 
 
 import jakarta.nosql.ValueReader;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import jakarta.nosql.TypeSupplier;
 import jakarta.nosql.ValueReaderDecorator;
 

--- a/diana/diana-core/src/main/java/org/jnosql/diana/reader/NavigableSetTypeReferenceReader.java
+++ b/diana/diana-core/src/main/java/org/jnosql/diana/reader/NavigableSetTypeReferenceReader.java
@@ -18,7 +18,7 @@ package org.jnosql.diana.reader;
 
 
 import jakarta.nosql.ValueReader;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import jakarta.nosql.TypeSupplier;
 import jakarta.nosql.ValueReaderDecorator;
 

--- a/diana/diana-core/src/main/java/org/jnosql/diana/reader/OptionalTypeReferenceReader.java
+++ b/diana/diana-core/src/main/java/org/jnosql/diana/reader/OptionalTypeReferenceReader.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.ValueReader;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import jakarta.nosql.TypeSupplier;
 import jakarta.nosql.ValueReaderDecorator;
 

--- a/diana/diana-core/src/main/java/org/jnosql/diana/reader/SetTypeReferenceReader.java
+++ b/diana/diana-core/src/main/java/org/jnosql/diana/reader/SetTypeReferenceReader.java
@@ -18,7 +18,7 @@ package org.jnosql.diana.reader;
 
 
 import jakarta.nosql.ValueReader;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import jakarta.nosql.TypeSupplier;
 import jakarta.nosql.ValueReaderDecorator;
 

--- a/diana/diana-core/src/main/java/org/jnosql/diana/reader/StreamTypeReferenceReader.java
+++ b/diana/diana-core/src/main/java/org/jnosql/diana/reader/StreamTypeReferenceReader.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import jakarta.nosql.TypeSupplier;
 import jakarta.nosql.ValueReader;
 import jakarta.nosql.ValueReaderDecorator;

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/ListTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/ListTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/MapTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/MapTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/NavigableSetTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/NavigableSetTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/OptionalTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/OptionalTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/QueueTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/QueueTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/SetTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/SetTypeReferenceReaderTest.java
@@ -17,7 +17,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/diana/diana-core/src/test/java/org/jnosql/diana/reader/StreamTypeReferenceReaderTest.java
+++ b/diana/diana-core/src/test/java/org/jnosql/diana/reader/StreamTypeReferenceReaderTest.java
@@ -18,7 +18,7 @@
 package org.jnosql.diana.reader;
 
 import jakarta.nosql.TypeReference;
-import jakarta.nosql.TypeReferenceReader;;
+import jakarta.nosql.TypeReferenceReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;


### PR DESCRIPTION
Eclipse-the-IDE considers these double semicolons syntax errors.