### PR TITLE
Clarify exception message in ParamValue#validValue

### DIFF
--- a/communication/communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
+++ b/communication/communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
@@ -72,7 +72,7 @@ final class ParamValue implements Value {
 
     private void validValue() {
         if (Objects.isNull(value)) {
-            throw new QueryException(String.format("The parameter %s is not defined", name));
+            throw new QueryException(String.format("The value of parameter %s cannot be null", name));
         }
     }
 


### PR DESCRIPTION
I found the earlier message for the null check in `ParamValue` to be confusing in practice, so this change is just to clarify that the query parameter value cannot be null.