### PR TITLE
Pass the Document to the custom AttributConverter when converting att…

### DIFF
--- a/mapping/mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentFieldConverters.java
+++ b/mapping/mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentFieldConverters.java
@@ -127,7 +127,8 @@ class DocumentFieldConverters {
                 Optional<Class<? extends AttributeConverter<X, Y>>> optionalConverter = field.getConverter();
                 if (optionalConverter.isPresent()) {
                     AttributeConverter<X, Y> attributeConverter = converter.getConverters().get(optionalConverter.get());
-                    Object attributeConverted = attributeConverter.convertToEntityAttribute((Y) value.get());
+                    Y attr = (Y)(value.isInstanceOf(List.class) ? document : value.get());
+                    Object attributeConverted = attributeConverter.convertToEntityAttribute((Y) attr);
                     field.write(instance, field.getValue(Value.of(attributeConverted)));
                 } else {
                     field.write(instance, field.getValue(value));


### PR DESCRIPTION
…ribute is not primitive type.

Currently the enclosed value is passed to the converter, what is good for the primitive types, but in a case  of the entity a list of properties is passed (List<Document>) which is counterintuitive. The Value would also be an option, but the Document is more similar to the TypeReferenceReader.