### PR TITLE
Fixed test assertions in order to improve the test coverage

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
@@ -44,8 +44,8 @@ class WhereTest {
         Where where = Where.of(condition);
         assertEquals(where, where,"should be equals to yourself");
         assertEquals(where, Where.of(condition));
-        assertNotEquals(new Object(), where,"should be not equal to an instance of any other type");
-        assertNotEquals(null, where,"should be not equal to null reference");
+        assertFalse(where.equals(new Object()),"should be not equal to an instance of any other type");
+        assertFalse(where.equals(null),"should be not equal to null reference");
     }
 
 


### PR DESCRIPTION
Fixed test assertions to use `assertFalse` assertion method because `assertEquals` assertion method doesn't call the target object `equals` method when the 1st provided parameter is `null`:

FYI, here are some snippet codes from the Junit Jupiter Assertions API that I'm talking about:

The `org.junit.jupiter.api.AssertEquals.assertEquals()` method:

```java
	static void assertEquals(Object expected, Object actual, Supplier<String> messageSupplier) {
		if (!objectsAreEqual(expected, actual)) {
			failNotEqual(expected, actual, messageSupplier);
		}
	}
```
And the `org.junit.jupiter.api.AssertionUtils.objectsAreEqual() `:

```java
	static boolean objectsAreEqual(Object obj1, Object obj2) {
		if (obj1 == null) {
			return (obj2 == null);
		}
		return obj1.equals(obj2);
	}
```
@otaviojava, could you review this PR, please?
