### PR TITLE
Add support to order by annotation

### DIFF
--- a/jnosql-communication/jnosql-communication-column/src/main/java/org/eclipse/jnosql/communication/column/ColumnConfiguration.java
+++ b/jnosql-communication/jnosql-communication-column/src/main/java/org/eclipse/jnosql/communication/column/ColumnConfiguration.java
@@ -44,7 +44,7 @@ public interface ColumnConfiguration extends Function<Settings, ColumnManagerFac
         return (T) ServiceLoader.load(ColumnConfiguration.class)
                 .stream()
                 .map(ServiceLoader.Provider::get)
-                .findFirst().orElseThrow(() -> new CommunicationException("It does not find ColumnConfiguration"));
+                .findFirst().orElseThrow(() -> new CommunicationException("No ColumnConfiguration implementation found!"));
     }
 
     /**
@@ -60,6 +60,6 @@ public interface ColumnConfiguration extends Function<Settings, ColumnManagerFac
                 .stream()
                 .map(ServiceLoader.Provider::get)
                 .filter(type::isInstance)
-                .findFirst().orElseThrow(() -> new CommunicationException("It does not find ColumnConfiguration"));
+                .findFirst().orElseThrow(() -> new CommunicationException("No ColumnConfiguration implementation found!"));
     }
 }

--- a/jnosql-communication/jnosql-communication-document/src/main/java/org/eclipse/jnosql/communication/document/DocumentConfiguration.java
+++ b/jnosql-communication/jnosql-communication-document/src/main/java/org/eclipse/jnosql/communication/document/DocumentConfiguration.java
@@ -42,7 +42,7 @@ public interface DocumentConfiguration extends Function<Settings, DocumentManage
         return (T) ServiceLoader.load(DocumentConfiguration.class)
                 .stream()
                 .map(ServiceLoader.Provider::get)
-                .findFirst().orElseThrow(() -> new CommunicationException("It does not find DocumentConfiguration"));
+                .findFirst().orElseThrow(() -> new CommunicationException("No DocumentConfiguration implementation found!"));
 
     }
 
@@ -59,6 +59,6 @@ public interface DocumentConfiguration extends Function<Settings, DocumentManage
                 .stream()
                 .map(ServiceLoader.Provider::get)
                 .filter(type::isInstance)
-                .findFirst().orElseThrow(() -> new CommunicationException("It does not find DocumentConfiguration"));
+                .findFirst().orElseThrow(() -> new CommunicationException("No DocumentConfiguration implementation found!"));
     }
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueConfiguration.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueConfiguration.java
@@ -38,7 +38,7 @@ public interface KeyValueConfiguration extends Function<Settings, BucketManagerF
        return (T) ServiceLoader.load(KeyValueConfiguration.class)
                 .stream()
                 .map(ServiceLoader.Provider::get)
-               .findFirst().orElseThrow(() -> new CommunicationException("It does not find KeyValueConfiguration"));
+               .findFirst().orElseThrow(() -> new CommunicationException("No KeyValueConfiguration implementation found!"));
     }
 
     /**
@@ -55,6 +55,6 @@ public interface KeyValueConfiguration extends Function<Settings, BucketManagerF
                 .stream()
                 .map(ServiceLoader.Provider::get)
                 .filter(type::isInstance)
-                .findFirst().orElseThrow(() -> new CommunicationException("It does not find KeyValueConfiguration"));
+                .findFirst().orElseThrow(() -> new CommunicationException("No KeyValueConfiguration implementation found!"));
     }
 }

--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
@@ -15,6 +15,7 @@
 package org.eclipse.jnosql.mapping.column.query;
 
 
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.PageableRepository;
 import org.eclipse.jnosql.communication.column.ColumnDeleteQuery;
 import org.eclipse.jnosql.communication.column.ColumnQuery;
@@ -52,6 +53,8 @@ public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRep
                 return executeCountByQuery(getQuery(method, args));
             case EXISTS_BY:
                 return executeExistsByQuery(getQuery(method, args));
+            case ORDER_BY:
+                throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case FIND_ALL:
                 ColumnQuery queryFindAll = ColumnQuery.select().from(getEntityMetadata().name()).build();
                 return executeFindByQuery(method, args, typeClass, updateQueryDynamically(args, queryFindAll));

--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
@@ -61,7 +61,7 @@ public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRep
                 return Void.class;
             case OBJECT_METHOD:
                 return method.invoke(this, args);
-            case JNOSQL_QUERY:
+            case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)
                         .withMethod(method)

--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
@@ -53,8 +53,6 @@ public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRep
                 return executeCountByQuery(getQuery(method, args));
             case EXISTS_BY:
                 return executeExistsByQuery(getQuery(method, args));
-            case ORDER_BY:
-                throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case FIND_ALL:
                 ColumnQuery queryFindAll = ColumnQuery.select().from(getEntityMetadata().name()).build();
                 return executeFindByQuery(method, args, typeClass, updateQueryDynamically(args, queryFindAll));
@@ -64,6 +62,8 @@ public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRep
                 return Void.class;
             case OBJECT_METHOD:
                 return method.invoke(this, args);
+            case ORDER_BY:
+                throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -14,6 +14,8 @@
  */
 package org.eclipse.jnosql.mapping.column.query;
 
+import jakarta.data.exceptions.MappingException;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
@@ -480,6 +482,18 @@ public class ColumnRepositoryProxyTest {
 
     }
 
+    @Test
+    public void shouldGotOrderException() {
+        Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findBy());
+    }
+
+    @Test
+    public void shouldGotOrderException2() {
+        Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findByException());
+    }
+
 
     @Test
     public void shouldFindByStringWhenFieldIsSet() {
@@ -730,6 +744,13 @@ public class ColumnRepositoryProxyTest {
         long countByName(String name);
 
         boolean existsByName(String name);
+
+        @OrderBy("name")
+        List<Person> findBy();
+
+        @OrderBy("name")
+        @OrderBy("age")
+        List<Person> findByException();
     }
 
     public interface VendorRepository extends PageableRepository<Vendor, String> {

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -94,7 +94,7 @@ public enum RepositoryType {
         if (IS_REPOSITORY_METHOD.test(declaringClass)) {
             return DEFAULT;
         }
-        if (method.getAnnotationsByType(OrderBy.class).length == 0) {
+        if (method.getAnnotationsByType(OrderBy.class).length > 0) {
             return ORDER_BY;
         }
         if (Objects.nonNull(method.getAnnotation(Query.class))) {

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -15,6 +15,7 @@
 package org.eclipse.jnosql.mapping.query;
 
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Query;
 
@@ -92,6 +93,9 @@ public enum RepositoryType {
         }
         if (IS_REPOSITORY_METHOD.test(declaringClass)) {
             return DEFAULT;
+        }
+        if (method.getAnnotationsByType(OrderBy.class).length == 0) {
+            return ORDER_BY;
         }
         if (Objects.nonNull(method.getAnnotation(Query.class))) {
             return QUERY;

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -61,7 +61,11 @@ public enum RepositoryType {
     /**
      * Method that has {@link Query} annotation
      */
-    QUERY("");
+    QUERY(""),
+    /**
+     * Method that has {@link jakarta.data.repository.OrderBy} annotation
+     */
+    ORDER_BY("");
 
     private static final Predicate<Class<?>> IS_REPOSITORY_METHOD = Predicate.<Class<?>>isEqual(CrudRepository.class)
             .or(Predicate.<Class<?>>isEqual(PageableRepository.class));

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -61,7 +61,7 @@ public enum RepositoryType {
     /**
      * Method that has {@link Query} annotation
      */
-    JNOSQL_QUERY("");
+    QUERY("");
 
     private static final Predicate<Class<?>> IS_REPOSITORY_METHOD = Predicate.<Class<?>>isEqual(CrudRepository.class)
             .or(Predicate.<Class<?>>isEqual(PageableRepository.class));
@@ -90,7 +90,7 @@ public enum RepositoryType {
             return DEFAULT;
         }
         if (Objects.nonNull(method.getAnnotation(Query.class))) {
-            return JNOSQL_QUERY;
+            return QUERY;
         }
 
         String methodName = method.getName();

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
@@ -81,6 +81,15 @@ class RepositoryTypeTest {
         Assertions.assertEquals(RepositoryType.EXISTS_BY, RepositoryType.of(getMethod(DevRepository.class, "existsByName")));
     }
 
+    @Test
+    public void shouldReturnOrder() throws NoSuchMethodException {
+        Assertions.assertEquals(RepositoryType.ORDER_BY, RepositoryType.of(getMethod(DevRepository.class,
+                "order")));
+
+        Assertions.assertEquals(RepositoryType.ORDER_BY, RepositoryType.of(getMethod(DevRepository.class,
+                "order2")));
+    }
+
     private Method getMethod(Class<?> repository, String methodName) throws NoSuchMethodException {
         return Stream.of(repository.getDeclaredMethods())
                 .filter(m -> m.getName().equals(methodName))

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
@@ -15,9 +15,11 @@
 package org.eclipse.jnosql.mapping.query;
 
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Query;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -102,6 +104,13 @@ class RepositoryTypeTest {
         Long existsByName(String name);
 
         void nope();
+
+        @OrderBy("sample")
+        String order();
+
+        @OrderBy("sample")
+        @OrderBy("test")
+        String order2();
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
@@ -61,7 +61,7 @@ class RepositoryTypeTest {
 
     @Test
     public void shouldReturnJNoSQLQuery() throws NoSuchMethodException {
-        Assertions.assertEquals(RepositoryType.JNOSQL_QUERY, RepositoryType.of(getMethod(DevRepository.class, "query")));
+        Assertions.assertEquals(RepositoryType.QUERY, RepositoryType.of(getMethod(DevRepository.class, "query")));
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
@@ -15,6 +15,7 @@
 package org.eclipse.jnosql.mapping.document.query;
 
 
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.PageableRepository;
 import org.eclipse.jnosql.communication.document.DocumentDeleteQuery;
 import org.eclipse.jnosql.communication.document.DocumentQuery;
@@ -60,6 +61,8 @@ public abstract class AbstractDocumentRepositoryProxy<T> extends BaseDocumentRep
                 return null;
             case OBJECT_METHOD:
                 return method.invoke(this, args);
+            case ORDER_BY:
+                throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
@@ -60,7 +60,7 @@ public abstract class AbstractDocumentRepositoryProxy<T> extends BaseDocumentRep
                 return null;
             case OBJECT_METHOD:
                 return method.invoke(this, args);
-            case JNOSQL_QUERY:
+            case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)
                         .withMethod(method)

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -14,7 +14,9 @@
  */
 package org.eclipse.jnosql.mapping.document.query;
 
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Sort;
@@ -553,6 +555,18 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
+    public void shouldGotOrderException() {
+        org.junit.jupiter.api.Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findBy());
+    }
+
+    @Test
+    public void shouldGotOrderException2() {
+        org.junit.jupiter.api.Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findByException());
+    }
+
+    @Test
     public void shouldExecuteJNoSQLQuery() {
         personRepository.findByQuery();
         verify(template).query("select * from Person");
@@ -755,6 +769,13 @@ public class DocumentCrudRepositoryProxyTest {
 
         @Query("select * from Person where id = @id")
         Optional<Person> findByQuery(@Param("id") String id);
+
+        @OrderBy("name")
+        List<Person> findBy();
+
+        @OrderBy("name")
+        @OrderBy("age")
+        List<Person> findByException();
     }
 
     public interface VendorRepository extends CrudRepository<Vendor, String> {

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
@@ -81,7 +81,7 @@ abstract class AbstractGraphRepositoryProxy<T, K> implements InvocationHandler {
                 return countBy(method, args);
             case EXISTS_BY:
                 return existsBy(method, args);
-            case JNOSQL_QUERY:
+            case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)
                         .withMethod(method)

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.graph.query;
 
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.Page;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.PageableRepository;
@@ -81,6 +82,8 @@ abstract class AbstractGraphRepositoryProxy<T, K> implements InvocationHandler {
                 return countBy(method, args);
             case EXISTS_BY:
                 return existsBy(method, args);
+            case ORDER_BY:
+                throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case QUERY:
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.graph.query;
 
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
@@ -417,6 +418,18 @@ public class GraphRepositoryProxyTest {
 
         boolean count = personRepository.existsByActiveTrue();
         assertFalse(count);
+    }
+
+    @Test
+    public void shouldGotOrderException() {
+        Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findBy());
+    }
+
+    @Test
+    public void shouldGotOrderException2() {
+        Assertions.assertThrows(MappingException.class, () ->
+                personRepository.findByException());
     }
     @Test
     public void shouldExecuteQuery2() {

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.graph.query;
 
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
@@ -491,6 +492,12 @@ public class GraphRepositoryProxyTest {
         @Query("g.V().hasLabel('Person').has('name', name).toList()")
         List<Person> findByQuery(@Param("name") String name);
 
+        @OrderBy("name")
+        List<Person> findBy();
+
+        @OrderBy("name")
+        @OrderBy("age")
+        List<Person> findByException();
     }
 
     public interface VendorRepository extends PageableRepository<Vendor, String> {

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/AbstractKeyValueRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/AbstractKeyValueRepositoryProxy.java
@@ -42,7 +42,7 @@ public abstract class AbstractKeyValueRepositoryProxy<T> implements InvocationHa
                 return method.invoke(getRepository(), args);
             case OBJECT_METHOD:
                 return method.invoke(this, args);
-            case JNOSQL_QUERY:
+            case QUERY:
                 Class<?> typeClass = getType();
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()
                         .withArgs(args)

--- a/pom.xml
+++ b/pom.xml
@@ -124,58 +124,68 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.verson}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.verson}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${microprofile.config.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${smallrye.config.version}</version>
+                <scope>test</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.eclipse.jnosql.communication</groupId>
                 <artifactId>jnosql-communication-query</artifactId>


### PR DESCRIPTION
This PR throws an exception on Order annotation when it does not support it.


## Changes

* Add exception MappingException when the repository uses OrderBy annotation.