### PR TITLE
Fix validation scan

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Fixed
+
+- Create a filter to ignore unsupported annotations on repositories interfaces.
+
 == [1.0.0-b6] - 2023-03-11
 
 === Changed

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
@@ -16,8 +16,11 @@ package org.eclipse.jnosql.mapping.reflection;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ClassRefTypeSignature;
 import io.github.classgraph.ClassTypeSignature;
+import io.github.classgraph.ReferenceTypeSignature;
 import io.github.classgraph.ScanResult;
+import io.github.classgraph.TypeArgument;
 import io.github.classgraph.TypeParameter;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.DataRepository;
@@ -63,21 +66,12 @@ public enum ClassScanner {
             embeddables.addAll(result.getClassesWithAnnotation(Embeddable.class).loadClasses());
             this.repositores.addAll(result.getClassesWithAnnotation(Repository.class)
                     .getInterfaces()
-                    .filter(isEntitySupported())
                     .loadClasses(DataRepository.class));
 
         }
         logger.fine(String.format("Finished the class scan with entities %d, embeddables %d and repositories: %d"
                 , entities.size(), embeddables.size(), repositores.size()));
 
-    }
-
-    private static ClassInfoList.ClassInfoFilter isEntitySupported() {
-        return c -> {
-            ClassTypeSignature signature = c.getTypeSignature();
-            List<TypeParameter> typeParameters = signature.getTypeParameters();
-            return true;
-        };
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
@@ -15,13 +15,7 @@
 package org.eclipse.jnosql.mapping.reflection;
 
 import io.github.classgraph.ClassGraph;
-import io.github.classgraph.ClassInfoList;
-import io.github.classgraph.ClassRefTypeSignature;
-import io.github.classgraph.ClassTypeSignature;
-import io.github.classgraph.ReferenceTypeSignature;
 import io.github.classgraph.ScanResult;
-import io.github.classgraph.TypeArgument;
-import io.github.classgraph.TypeParameter;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.PageableRepository;
@@ -34,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ClassScanner.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -67,13 +68,12 @@ public enum ClassScanner {
             this.repositores.addAll(result.getClassesWithAnnotation(Repository.class)
                     .getInterfaces()
                     .loadClasses(DataRepository.class));
-
+            this.repositores.removeIf(UnsupportedRepositoryFilter.INSTANCE);
         }
         logger.fine(String.format("Finished the class scan with entities %d, embeddables %d and repositories: %d"
                 , entities.size(), embeddables.size(), repositores.size()));
 
     }
-
 
     /**
      * Returns the classes that that has the {@link Entity} annotation

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -16,9 +16,12 @@ package org.eclipse.jnosql.mapping.reflection;
 
 import java.util.function.Predicate;
 
-class UnsupportedRepositoryFilter implements Predicate<Class<?>> {
+enum UnsupportedRepositoryFilter implements Predicate<Class<?>> {
+
+    INSTANCE;
+
     @Override
-    public boolean test(Class<?> aClass) {
+    public boolean test(Class<?> type) {
         return false;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -33,6 +33,9 @@ enum UnsupportedRepositoryFilter implements Predicate<Class<?>> {
     @Override
     public boolean test(Class<?> type) {
         Type[] interfaces = type.getGenericInterfaces();
+        if (interfaces.length == 0) {
+            return true;
+        }
         ParameterizedType param = (ParameterizedType) interfaces[0];
         Type[] arguments = param.getActualTypeArguments();
         if (arguments.length == 0) {

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -14,14 +14,25 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.function.Predicate;
 
+/**
+ *A filter to remove any Repository that Eclipse JNoSQL does not support. It will check the first parameter
+ * on the repository, and if the entity has not had an unsupported annotation,
+ * it will return false and true to supported Repository.
+ */
 enum UnsupportedRepositoryFilter implements Predicate<Class<?>> {
 
     INSTANCE;
 
     @Override
     public boolean test(Class<?> type) {
+        Type[] interfaces = type.getGenericInterfaces();
+        ParameterizedType param = (ParameterizedType) interfaces[0];
+        Type[] arguments = param.getActualTypeArguments();
+        Class<?> entity = (Class<?>) arguments[0];
         return false;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import java.util.function.Predicate;
+
+class UnsupportedRepositoryFilter implements Predicate<Class<?>> {
+    @Override
+    public boolean test(Class<?> aClass) {
+        return false;
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -36,13 +36,13 @@ enum UnsupportedRepositoryFilter implements Predicate<Class<?>> {
         ParameterizedType param = (ParameterizedType) interfaces[0];
         Type[] arguments = param.getActualTypeArguments();
         if (arguments.length == 0) {
-            return false;
+            return true;
         }
         Type argument = arguments[0];
         if (argument instanceof Class<?> entity) {
-            return entity.getAnnotation(Entity.class) != null;
+            return entity.getAnnotation(Entity.class) == null;
         }
 
-        return false;
+        return true;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilter.java
@@ -14,12 +14,15 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
+
+import jakarta.nosql.Entity;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 
 /**
- *A filter to remove any Repository that Eclipse JNoSQL does not support. It will check the first parameter
+ * A filter to remove any Repository that Eclipse JNoSQL does not support. It will check the first parameter
  * on the repository, and if the entity has not had an unsupported annotation,
  * it will return false and true to supported Repository.
  */
@@ -32,7 +35,14 @@ enum UnsupportedRepositoryFilter implements Predicate<Class<?>> {
         Type[] interfaces = type.getGenericInterfaces();
         ParameterizedType param = (ParameterizedType) interfaces[0];
         Type[] arguments = param.getActualTypeArguments();
-        Class<?> entity = (Class<?>) arguments[0];
+        if (arguments.length == 0) {
+            return false;
+        }
+        Type argument = arguments[0];
+        if (argument instanceof Class<?> entity) {
+            return entity.getAnnotation(Entity.class) != null;
+        }
+
         return false;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -38,16 +38,16 @@ class UnsupportedRepositoryFilterTest {
     }
 
     @Test
-    public void shouldReturnTrueWhenHasSupportRepository() {
-        assertThat(predicate.test(PersonRepository.class)).isTrue();
-        assertThat(predicate.test(People.class)).isTrue();
-        assertThat(predicate.test(Persons.class)).isTrue();
+    public void shouldReturnFalseWhenHasSupportRepository() {
+        assertThat(predicate.test(PersonRepository.class)).isFalse();
+        assertThat(predicate.test(People.class)).isFalse();
+        assertThat(predicate.test(Persons.class)).isFalse();
     }
 
     @Test
-    public void shouldReturnFalseWhenHasSupportRepository() {
-        assertThat(predicate.test(NoSQLVendor.class)).isFalse();
-        assertThat(predicate.test(Server.class)).isFalse();
+    public void shouldReturnTrueWhenHasSupportRepository() {
+        assertThat(predicate.test(NoSQLVendor.class)).isTrue();
+        assertThat(predicate.test(Server.class)).isTrue();
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnsupportedRepositoryFilterTest {
+
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -42,12 +42,15 @@ class UnsupportedRepositoryFilterTest {
         assertThat(predicate.test(PersonRepository.class)).isFalse();
         assertThat(predicate.test(People.class)).isFalse();
         assertThat(predicate.test(Persons.class)).isFalse();
+
     }
 
     @Test
     public void shouldReturnTrueWhenHasSupportRepository() {
         assertThat(predicate.test(NoSQLVendor.class)).isTrue();
         assertThat(predicate.test(Server.class)).isTrue();
+        assertThat(predicate.test(StringSupplier.class)).isTrue();
+        assertThat(predicate.test(Repository.class)).isTrue();
     }
 
 
@@ -63,8 +66,13 @@ class UnsupportedRepositoryFilterTest {
 
     }
 
+    private interface StringSupplier extends Supplier<String> {
 
+    }
 
+    private interface Repository {
+
+    }
 
     private class Computer {
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
+import org.eclipse.jnosql.mapping.test.entities.NoSQLVendor;
 import org.eclipse.jnosql.mapping.test.entities.PersonRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,5 +35,10 @@ class UnsupportedRepositoryFilterTest {
     @Test
     public void shouldReturnTrueWhenHasSupportRepository() {
         assertThat(predicate.test(PersonRepository.class)).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseWhenHasSupportRepository() {
+        assertThat(predicate.test(NoSQLVendor.class)).isFalse();
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -14,12 +14,15 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
+import jakarta.data.repository.PageableRepository;
 import org.eclipse.jnosql.mapping.test.entities.NoSQLVendor;
+import org.eclipse.jnosql.mapping.test.entities.Person;
 import org.eclipse.jnosql.mapping.test.entities.PersonRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,10 +38,21 @@ class UnsupportedRepositoryFilterTest {
     @Test
     public void shouldReturnTrueWhenHasSupportRepository() {
         assertThat(predicate.test(PersonRepository.class)).isTrue();
+        assertThat(predicate.test(People.class)).isTrue();
+        assertThat(predicate.test(Persons.class)).isTrue();
     }
 
     @Test
     public void shouldReturnFalseWhenHasSupportRepository() {
         assertThat(predicate.test(NoSQLVendor.class)).isFalse();
+    }
+
+
+    private interface People extends PageableRepository<Person, Long>, Supplier<String> {
+
+    }
+
+    private interface Persons extends Supplier<String>, PageableRepository<Person, Long> {
+
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.jnosql.mapping.reflection;
 
 import jakarta.data.repository.PageableRepository;
+import jakarta.nosql.Column;
+import jakarta.nosql.Id;
 import org.eclipse.jnosql.mapping.test.entities.NoSQLVendor;
 import org.eclipse.jnosql.mapping.test.entities.Person;
 import org.eclipse.jnosql.mapping.test.entities.PersonRepository;
@@ -45,6 +47,7 @@ class UnsupportedRepositoryFilterTest {
     @Test
     public void shouldReturnFalseWhenHasSupportRepository() {
         assertThat(predicate.test(NoSQLVendor.class)).isFalse();
+        assertThat(predicate.test(Server.class)).isFalse();
     }
 
 
@@ -54,5 +57,21 @@ class UnsupportedRepositoryFilterTest {
 
     private interface Persons extends Supplier<String>, PageableRepository<Person, Long> {
 
+    }
+
+    private interface Server extends PageableRepository<Computer, String> {
+
+    }
+
+
+
+
+    private class Computer {
+
+        @Id
+        private String id;
+
+        @Column
+        private String name;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -51,11 +51,11 @@ class UnsupportedRepositoryFilterTest {
     }
 
 
-    private interface People extends PageableRepository<Person, Long>, Supplier<String> {
+    private interface People extends PageableRepository<Person, Long> {
 
     }
 
-    private interface Persons extends Supplier<String>, PageableRepository<Person, Long> {
+    private interface Persons extends PageableRepository<Person, Long> {
 
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/UnsupportedRepositoryFilterTest.java
@@ -14,8 +14,25 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.eclipse.jnosql.mapping.test.entities.PersonRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class UnsupportedRepositoryFilterTest {
 
+    private Predicate<Class<?>> predicate;
+
+    @BeforeEach
+    public void setUp() {
+        this.predicate = UnsupportedRepositoryFilter.INSTANCE;
+    }
+
+    @Test
+    public void shouldReturnTrueWhenHasSupportRepository() {
+        assertThat(predicate.test(PersonRepository.class)).isTrue();
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/test/entities/User.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/test/entities/User.java
@@ -14,11 +14,13 @@
  */
 package org.eclipse.jnosql.mapping.test.entities;
 
+import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
 
 import java.util.Objects;
 
 
+@Entity
 public class User {
 
     @Id


### PR DESCRIPTION
Ignores any data repository where the entity has an annotation that Eclipse JNoSQL does not support.



## Fixed

- Create a filter to ignore unsupported annotations on repositories interfaces.