### PR TITLE
Add Java 20 CI

### DIFF
--- a/.github/workflows/java-20.yml
+++ b/.github/workflows/java-20.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java 20 CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 20
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 20
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven
+      - name: Build with Maven
+        run: mvn -P java-20 -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     </developers>
     <properties>
         <apache.rat.version>0.12</apache.rat.version>
-        <jacoco.maven.version>0.8.8</jacoco.maven.version>
+        <jacoco.maven.version>0.8.9-SNAPSHOT</jacoco.maven.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.enterprise.cdi.version>4.0.1</jakarta.enterprise.cdi.version>
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
@@ -600,4 +600,19 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <!-- Needed to download jacoco 0.8.9 snapshot. Once it is officially released, we can remove this  -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java-20</id>
+            <properties>
+                <maven.compiler.source>20</maven.compiler.source>
+                <maven.compiler.target>20</maven.compiler.target>
+                <maven.compiler.release>20</maven.compiler.release>
+            </properties>
+        </profile>
     </profiles>
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
Solves #352 

- Adds a maven profile to override the project default java version (`<maven.compiler.source>17</maven.compiler.source>`)
- Adds a new github action building with java 20
- Updates jacoco to 0.8.9-SNAPSHOT

Updating Jacoco was needed since jacoco 0.8.8 supports up to java 18 (19 with experimental support), which causes the build with java 20 to fail.
However, jacoco 0.8.9 adds support to java 20. The only problem is that jacoco 0.8.9 hasn't been officially released yet.

Alternatively, I can change it to use jacoco 0.8.9 only when running the java 20 CI.

If my changes here are ok, I'll replicate them on the [communication](https://github.com/eclipse/jnosql-communication-driver) and [extension](https://github.com/eclipse/jnosql-mapping-extension) repositories

