### PR TITLE
Test refactoring and Mockito bump

### DIFF
--- a/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/reader/OptionalReaderTest.java
+++ b/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/reader/OptionalReaderTest.java
@@ -48,8 +48,8 @@ class OptionalReaderTest {
     @DisplayName("Should be abe to convert to Optional")
     void shouldConvert() {
         assertSoftly(softly -> {
-            softly.assertThat(valueReader.read(Optional.class, "12")).isEqualTo(Optional.of("12")).as("Default conversion");
-            softly.assertThat(valueReader.read(Optional.class, Optional.of("value"))).isEqualTo(Optional.of("value")).as("Optional conversion");
+            softly.assertThat(valueReader.read(Optional.class, "12")).isEqualTo(Optional.of("12"));
+            softly.assertThat(valueReader.read(Optional.class, Optional.of("value"))).isEqualTo(Optional.of("value"));
         });
     }
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/DefaultKeyValuePreparedStatement.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/DefaultKeyValuePreparedStatement.java
@@ -12,11 +12,10 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Elias Nogueira
  *
  */
 package org.eclipse.jnosql.communication.keyvalue;
-
-
 
 import jakarta.data.exceptions.NonUniqueResultException;
 import org.eclipse.jnosql.communication.Params;
@@ -47,11 +46,8 @@ final class DefaultKeyValuePreparedStatement implements KeyValuePreparedStatemen
     private final Value key;
     private final Value value;
 
-    DefaultKeyValuePreparedStatement(Value key, Value value, List<Value> keys,
-                                     PreparedStatementType type,
-                                     BucketManager manager,
-                                     Params params,
-                                     Duration ttl, String query) {
+    DefaultKeyValuePreparedStatement(Value key, Value value, List<Value> keys, PreparedStatementType type,
+                                     BucketManager manager, Params params, Duration ttl, String query) {
         this.key = key;
         this.value = value;
         this.keys = keys;
@@ -76,19 +72,18 @@ final class DefaultKeyValuePreparedStatement implements KeyValuePreparedStatemen
     @Override
     public Stream<Value> result() {
         if (!paramsLeft.isEmpty()) {
-            throw new QueryException("Check all the parameters before execute the query, params left: "
-                    + paramsLeft);
+            throw new QueryException("Check all the parameters before execute the query, params left: " + paramsLeft);
         }
+
         switch (type) {
-            case GET:
-                return keys.stream().map(Value::get)
-                        .map(manager::get)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get);
-            case DEL:
+            case GET -> {
+                return keys.stream().map(Value::get).map(manager::get).filter(Optional::isPresent).map(Optional::get);
+            }
+            case DEL -> {
                 manager.delete(keys.stream().map(Value::get).collect(Collectors.toList()));
                 return Stream.empty();
-            case PUT:
+            }
+            case PUT -> {
                 KeyValueEntity entity = KeyValueEntity.of(key.get(), value.get());
                 if (Objects.isNull(ttl)) {
                     manager.put(entity);
@@ -96,19 +91,20 @@ final class DefaultKeyValuePreparedStatement implements KeyValuePreparedStatemen
                     manager.put(entity, ttl);
                 }
                 return Stream.empty();
-            default:
-                throw new UnsupportedOperationException("there is not support to operation type: " + type);
+            }
+            default -> throw new UnsupportedOperationException("there is not support to operation type: " + type);
         }
     }
 
     @Override
     public Optional<Value> singleResult() {
         Stream<Value> entities = result();
-        final Iterator<Value> iterator = entities.iterator();
 
+        final Iterator<Value> iterator = entities.iterator();
         if (!iterator.hasNext()) {
             return Optional.empty();
         }
+
         final Value next = iterator.next();
         if (!iterator.hasNext()) {
             return Optional.of(next);
@@ -121,28 +117,15 @@ final class DefaultKeyValuePreparedStatement implements KeyValuePreparedStatemen
         GET, PUT, DEL
     }
 
-    static KeyValuePreparedStatement get(List<Value> keys,
-                                         BucketManager manager,
-                                         Params params, String query) {
-        return new DefaultKeyValuePreparedStatement(null, null, keys, PreparedStatementType.GET,
-                manager, params, null, query);
+    static KeyValuePreparedStatement get(List<Value> keys, BucketManager manager, Params params, String query) {
+        return new DefaultKeyValuePreparedStatement(null, null, keys, PreparedStatementType.GET, manager, params, null, query);
     }
 
-    static KeyValuePreparedStatement put(Value key,
-                                         Value value,
-                                         BucketManager manager,
-                                         Params params,
-                                         Duration ttl, String query) {
-        return new DefaultKeyValuePreparedStatement(key, value, null, PreparedStatementType.PUT,
-                manager, params, ttl, query);
+    static KeyValuePreparedStatement put(Value key, Value value, BucketManager manager, Params params, Duration ttl, String query) {
+        return new DefaultKeyValuePreparedStatement(key, value, null, PreparedStatementType.PUT, manager, params, ttl, query);
     }
 
-    static KeyValuePreparedStatement del(List<Value> keys,
-                                         BucketManager manager,
-                                         Params params, String query) {
-        return new DefaultKeyValuePreparedStatement(null, null, keys, PreparedStatementType.DEL,
-                manager, params, null, query);
+    static KeyValuePreparedStatement del(List<Value> keys, BucketManager manager, Params params, String query) {
+        return new DefaultKeyValuePreparedStatement(null, null, keys, PreparedStatementType.DEL, manager, params, null, query);
     }
-
-
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueQueryParser.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueQueryParser.java
@@ -12,19 +12,16 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Elias Nogueira
  *
  */
 package org.eclipse.jnosql.communication.keyvalue;
-
 
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.Value;
 
 import java.util.Objects;
 import java.util.stream.Stream;
-
-
-
 
 /**
  * A query parser to key-value database type, this class will convert a String to an operation in {@link BucketManager}.
@@ -49,18 +46,14 @@ final class KeyValueQueryParser {
     public Stream<Value> query(String query, BucketManager manager) {
         validation(query, manager);
         String command = query.substring(0, 3);
-        switch (command) {
-            case "get":
-                return getQueryParser.query(query, manager);
-            case "del":
-                return delQueryParser.query(query, manager);
-            case "put":
-                return putQueryParser.query(query, manager);
-            default:
-                throw new QueryException(String.format("The command was not recognized at the query %s ", query));
-        }
+        return switch (command) {
+            case "get" -> getQueryParser.query(query, manager);
+            case "del" -> delQueryParser.query(query, manager);
+            case "put" -> putQueryParser.query(query, manager);
+            default ->
+                    throw new QueryException(String.format("The command was not recognized at the query %s ", query));
+        };
     }
-
 
     /**
      * Executes a query and returns a {@link KeyValuePreparedStatement}, when the operations are <b>insert</b>, <b>update</b> and <b>select</b>
@@ -76,16 +69,13 @@ final class KeyValueQueryParser {
     public KeyValuePreparedStatement prepare(String query, BucketManager manager) {
         validation(query, manager);
         String command = query.substring(0, 3);
-        switch (command) {
-            case "get":
-                return getQueryParser.prepare(query, manager);
-            case "del":
-                return delQueryParser.prepare(query, manager);
-            case "put":
-                return putQueryParser.prepare(query, manager);
-            default:
-                throw new QueryException(String.format("The command was not recognized at the query %s ", query));
-        }
+        return switch (command) {
+            case "get" -> getQueryParser.prepare(query, manager);
+            case "del" -> delQueryParser.prepare(query, manager);
+            case "put" -> putQueryParser.prepare(query, manager);
+            default ->
+                    throw new QueryException(String.format("The command was not recognized at the query %s ", query));
+        };
     }
 
     private void validation(String query, BucketManager manager) {

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/DelQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/DelQueryParserTest.java
@@ -12,138 +12,124 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Elias Nogueira
  *
  */
 package org.eclipse.jnosql.communication.keyvalue;
 
 import org.eclipse.jnosql.communication.QueryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class DelQueryParserTest {
 
     private final DelQueryParser parser = new DelQueryParser();
 
-    private final BucketManager manager = Mockito.mock(BucketManager.class);
+    @Mock
+    private BucketManager manager;
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del \"Diana\""})
-    public void shouldReturnParserQuery1(String query) {
+    @Captor
+    private ArgumentCaptor<List<Object>> captor;
 
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
-
+    @ParameterizedTest(name = "Should be able to parse query: '{0}'")
+    @MethodSource("queryData")
+    void shouldReturnParserQuery(String query, Object expected) {
         parser.query(query, manager);
+        verify(manager).delete(captor.capture());
 
-        Mockito.verify(manager).delete(captor.capture());
         List<Object> value = captor.getValue();
-
-        assertEquals(1, value.size());
-        assertThat(value).contains("Diana");
+        assertThat(value).contains(expected);
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del 12"})
-    public void shouldReturnParserQuery2(String query) {
-
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
-
-        parser.query(query, manager);
-
-        Mockito.verify(manager).delete(captor.capture());
-        List<Object> value = captor.getValue();
-
-        assertEquals(1, value.size());
-        assertThat(value).contains(12L);
+    @Test
+    @DisplayName("Should throw QueryException when use parameter in query")
+    void shouldReturnErrorWhenUseParameterInQuery() {
+        assertThatThrownBy(() -> parser.query("del @id", manager))
+                .isInstanceOf(QueryException.class)
+                .hasMessage("To run a query with a parameter use a PrepareStatement instead.");
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del {\"Ana\" : \"Sister\", \"Maria\" : \"Mother\"}"})
-    public void shouldReturnParserQuery3(String query) {
+    @Test
+    @DisplayName("Should throw QueryException when parameter is not bind")
+    void shouldReturnErrorWhenCannotBindParameters() {
+        KeyValuePreparedStatement prepare = parser.prepare("del @id", manager);
 
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
-
-        parser.query(query, manager);
-
-        Mockito.verify(manager).delete(captor.capture());
-        List<Object> value = captor.getValue();
-
-        assertEquals(1, value.size());
-        assertThat(value).contains("{\"Ana\":\"Sister\",\"Maria\":\"Mother\"}");
+        assertThatThrownBy(prepare::result)
+                .isInstanceOf(QueryException.class)
+                .hasMessage("Check all the parameters before execute the query, params left: [id]");
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del convert(\"2018-01-10\", java.time.LocalDate)"})
-    public void shouldReturnParserQuery4(String query) {
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
+    @Test
+    @DisplayName("Should be able to execute the PreparedStatement using one parameter")
+    void shouldExecutePrepareStatementUsingOneParameter() {
+        String query = "del @id";
 
-        parser.query(query, manager);
-
-        Mockito.verify(manager).delete(captor.capture());
-        List<Object> value = captor.getValue();
-
-        assertEquals(1, value.size());
-
-        assertThat(value).contains(LocalDate.parse("2018-01-10"));
-    }
-
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"remove @id"})
-    public void shouldReturnErrorWhenUseParameterInQuery(String query) {
-        assertThrows(QueryException.class, () -> parser.query(query, manager));
-    }
-
-
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del @id"})
-    public void shouldReturnErrorWhenDontBindParameters(String query) {
-
-        KeyValuePreparedStatement prepare = parser.prepare(query, manager);
-        assertThrows(QueryException.class, prepare::result);
-    }
-
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del @id"})
-    public void shouldExecutePrepareStatement(String query) {
-
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
         KeyValuePreparedStatement prepare = parser.prepare(query, manager);
         prepare.bind("id", 10);
         prepare.result();
 
-        Mockito.verify(manager).delete(captor.capture());
+        verify(manager).delete(captor.capture());
         List<Object> value = captor.getValue();
 
-        assertEquals(1, value.size());
-
-        assertThat(value).contains(10);
+        assertThat(value).hasSize(1).contains(10);
     }
 
+    @Test
+    @DisplayName("Should be able to execute the PreparedStatement using two parameter")
+    void shouldExecutePrepareStatementUsingTwoParameter() {
+        String query = "del @id, @id2";
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del @id, @id2"})
-    public void shouldExecutePrepareStatement2(String query) {
-
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
         KeyValuePreparedStatement prepare = parser.prepare(query, manager);
         prepare.bind("id", 10);
         prepare.bind("id2", 11);
         prepare.result();
 
-        Mockito.verify(manager).delete(captor.capture());
+        verify(manager).delete(captor.capture());
         List<Object> value = captor.getValue();
 
-        assertEquals(2, value.size());
-
-        assertThat(value).contains(10, 11);
+        assertThat(value).hasSize(2).contains(10, 11);
     }
 
+    private static Stream<Arguments> queryData() {
+        String query1 = """
+                del "Diana"
+                """;
+
+        String query2 = "del 12";
+
+        String query3 = """
+                del { "Ana": "Sister", "Maria": "Mother" }
+                """;
+
+        String query4 = """
+                del convert("2018-01-10", java.time.LocalDate)
+                """;
+
+        String resultOfQuery3 = """
+                {"Ana":"Sister","Maria":"Mother"}
+                """;
+        return Stream.of(
+                Arguments.of(query1, "Diana"),
+                Arguments.of(query2, 12L),
+                Arguments.of(query3, resultOfQuery3.trim()),
+                Arguments.of(query4, LocalDate.parse("2018-01-10"))
+        );
+    }
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/GetQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/GetQueryParserTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -57,13 +58,10 @@ class GetQueryParserTest {
         verify(manager, never()).get(any(Object.class));
         stream.collect(toList());
 
-        verify(manager).get(assertArg(value ->
-                assertThat(value).contains(expected)));
+        verify(manager).get(captor.capture());
+        List<Object> value = captor.getAllValues();
 
-//        verify(manager).get(captor.capture());
-//        List<Object> value = captor.getAllValues();
-//
-//        assertThat(value).contains(expected);
+        assertThat(value).contains(expected);
     }
 
     @Test
@@ -91,13 +89,10 @@ class GetQueryParserTest {
         prepare.bind("id", 10);
         prepare.result().toList();
 
-        verify(manager).get(assertArg(value ->
-                assertThat(value).hasSize(1).contains(10)));
+        verify(manager).get(captor.capture());
+        List<Object> value = captor.getAllValues();
 
-//        verify(manager).get(captor.capture());
-//        List<Object> value = captor.getAllValues();
-//
-//        assertThat(value).hasSize(1).contains(10);
+        assertThat(value).hasSize(1).contains(10);
     }
 
     @Test
@@ -110,16 +105,10 @@ class GetQueryParserTest {
         final Stream<Value> stream = prepare.result();
         stream.collect(toList());
 
-//        verify(manager, times(2)).get(assertArg(value ->
-//                assertThat(value).hasSize(2).contains(10, 11)));
+        verify(manager, times(2)).get(captor.capture());
+        List<Object> value = captor.getAllValues();
 
-        verify(manager, times(2)).get(assertArg(value ->
-                assertThat(value).isNull()));
-
-//        verify(manager, times(2)).get(captor.capture());
-//        List<Object> value = captor.getAllValues();
-//
-//        assertThat(value).hasSize(2).contains(10, 11);
+        assertThat(value).hasSize(2).contains(10, 11);
     }
 
     static Stream<Arguments> queryData() {

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/GetQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/GetQueryParserTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -50,7 +49,7 @@ class GetQueryParserTest {
     @Captor
     private ArgumentCaptor<Object> captor;
 
-    @ParameterizedTest(name = "Should be able to parse query: '{0}'")
+    @ParameterizedTest(name = "Should be able to parse query: {0}")
     @MethodSource("queryData")
     void shouldReturnParserQuery(String query, Object expected) {
         final Stream<Value> stream = parser.query(query, manager);
@@ -58,10 +57,13 @@ class GetQueryParserTest {
         verify(manager, never()).get(any(Object.class));
         stream.collect(toList());
 
-        verify(manager).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+        verify(manager).get(assertArg(value ->
+                assertThat(value).contains(expected)));
 
-        assertThat(value).contains(expected);
+//        verify(manager).get(captor.capture());
+//        List<Object> value = captor.getAllValues();
+//
+//        assertThat(value).contains(expected);
     }
 
     @Test
@@ -87,12 +89,15 @@ class GetQueryParserTest {
     void shouldExecutePrepareStatement() {
         KeyValuePreparedStatement prepare = parser.prepare("get @id", manager);
         prepare.bind("id", 10);
-        prepare.result().collect(toList());
+        prepare.result().toList();
 
-        verify(manager).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+        verify(manager).get(assertArg(value ->
+                assertThat(value).hasSize(1).contains(10)));
 
-        assertThat(value).hasSize(1).contains(10);
+//        verify(manager).get(captor.capture());
+//        List<Object> value = captor.getAllValues();
+//
+//        assertThat(value).hasSize(1).contains(10);
     }
 
     @Test
@@ -105,10 +110,16 @@ class GetQueryParserTest {
         final Stream<Value> stream = prepare.result();
         stream.collect(toList());
 
-        verify(manager, times(2)).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+//        verify(manager, times(2)).get(assertArg(value ->
+//                assertThat(value).hasSize(2).contains(10, 11)));
 
-        assertThat(value).hasSize(2).contains(10, 11);
+        verify(manager, times(2)).get(assertArg(value ->
+                assertThat(value).isNull()));
+
+//        verify(manager, times(2)).get(captor.capture());
+//        List<Object> value = captor.getAllValues();
+//
+//        assertThat(value).hasSize(2).contains(10, 11);
     }
 
     static Stream<Arguments> queryData() {

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueEntityParamsTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueEntityParamsTest.java
@@ -13,28 +13,30 @@
  *
  *   Otavio Santana
  *   Maximillian Arruda
+ *   Elias Nogueira
  */
 package org.eclipse.jnosql.communication.keyvalue;
 
 import org.eclipse.jnosql.communication.Params;
 import org.eclipse.jnosql.communication.Value;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class KeyValueEntityParamsTest {
 
     @Test
-    public void shouldSetParameter() {
+    @DisplayName("Should be able to set and change a parameter value")
+    void shouldSetParameter() {
         Params params = Params.newParams();
         Value name = params.add("name");
+
         KeyValueEntity entity = KeyValueEntity.of("name", name);
         params.bind("name", "Ada Lovelace");
-
-        assertEquals("Ada Lovelace", entity.value());
+        assertThat(entity.value()).isEqualTo("Ada Lovelace");
 
         params.bind("name", "Diana");
-        assertEquals("Diana", entity.value());
+        assertThat(entity.value()).isEqualTo("Diana");
     }
-
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueEntityTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueEntityTest.java
@@ -12,96 +12,94 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Elias Nogueira
  *
  */
 package org.eclipse.jnosql.communication.keyvalue;
 
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+class KeyValueEntityTest {
 
-public class KeyValueEntityTest {
+    public static final String KEY = "key";
+    public static final String VALUE = "VALUE";
 
     @Test
-    public void shouldReturnErrorWhenKeyIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> KeyValueEntity.of(null, "value"));
+    @DisplayName("Should throw NullPointerException when key is null")
+    void shouldReturnErrorWhenKeyIsNull() {
+        assertThatNullPointerException().isThrownBy(() -> KeyValueEntity.of(null, VALUE)).withMessage("key is required");
     }
 
     @Test
-    public void shouldReturnErrorWhenValueIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> KeyValueEntity.of("key", null));
+    @DisplayName("Should throw NullPointerException when value is null")
+    void shouldReturnErrorWhenValueIsNull() {
+        assertThatNullPointerException().isThrownBy(() -> KeyValueEntity.of(KEY, null)).withMessage("value is required");
     }
 
     @Test
-    public void shouldCreateInstance() {
-        KeyValueEntity entity = KeyValueEntity.of("key", "value");
-        assertNotNull(entity);
-        assertEquals("key", entity.key());
-        assertEquals("value", entity.value());
+    @DisplayName("Should be able to create a KeyValueEntity")
+    void shouldCreateInstance() {
+        KeyValueEntity entity = KeyValueEntity.of(KEY, VALUE);
+
+        assertSoftly(softly -> {
+            softly.assertThat(entity.key()).as("key is required").isEqualTo(KEY);
+            softly.assertThat(entity.value()).as("value is required").isEqualTo(VALUE);
+        });
     }
 
     @Test
-    public void shouldAliasOnValue() {
-        String value = "10";
-        KeyValueEntity entity = KeyValueEntity.of("key", value);
-        assertEquals(value, entity.value());
-        assertEquals(Integer.valueOf(10), entity.value(Integer.class));
-        assertThat(singletonList(10)).contains(entity.value(new TypeReference<List<Integer>>() {
-        }).get(0));
+    @DisplayName("Should be able to get the value")
+    void shouldGetValue() {
+        Value value = Value.of(VALUE);
+        KeyValueEntity entity = KeyValueEntity.of(KEY, value);
+
+        assertThat(entity.value()).isEqualTo(value.get());
     }
 
     @Test
-    public void shouldGetValue() {
-        Value value = Value.of("value");
-        KeyValueEntity entity = KeyValueEntity.of("key", value);
-        assertNotNull(entity);
-        assertEquals("value", entity.value());
-    }
-
-
-    @Test
-    public void shouldGetKeyClass() {
-        Value value = Value.of("value");
+    @DisplayName("Should be able to get the key by class")
+    void shouldGetKeyClass() {
+        Value value = Value.of(VALUE);
         KeyValueEntity entity = KeyValueEntity.of("10", value);
-        assertNotNull(entity);
-        assertEquals(Long.valueOf(10L), entity.key(Long.class));
+
+        assertThat(entity.key(Long.class)).isEqualTo(10L);
     }
 
-
     @Test
-    public void shouldReturnErrorWhenGetKeyClassIsNull() {
-        Value value = Value.of("value");
+    @DisplayName("Should throw NullPointerException when Class is null")
+    void shouldReturnErrorWhenGetKeyClassIsNull() {
+        Value value = Value.of(VALUE);
         KeyValueEntity entity = KeyValueEntity.of("10", value);
-        assertNotNull(entity);
-        Assertions.assertThrows(NullPointerException.class, () -> entity.key((Class<Object>) null));
+
+        assertThatNullPointerException().isThrownBy(() -> entity.key((Class<Object>) null)).withMessage("type is required");
     }
 
-
     @Test
-    public void shouldGetKeyValueSupplier() {
+    @DisplayName("Should be able to get the key by TypeSupplier")
+    void shouldGetKeyValueSupplier() {
         String value = "10";
         KeyValueEntity entity = KeyValueEntity.of(value, value);
-        assertEquals(value, entity.value());
-        assertEquals(Integer.valueOf(10), entity.key(Integer.class));
-        assertThat(singletonList(10)).contains(entity.value(new TypeReference<List<Integer>>() {
-        }).get(0));
+
+        assertThat(entity.value(new TypeReference<List<Integer>>() {
+        })).isEqualTo(singletonList(10));
     }
 
     @Test
-    public void shouldReturnErrorWhenGetKeySupplierIsNull() {
+    @DisplayName("Should throw NullPointerException when TypeSupplier is null")
+    void shouldReturnErrorWhenGetKeySupplierIsNull() {
         Value value = Value.of("value");
         KeyValueEntity entity = KeyValueEntity.of("10", value);
-        assertNotNull(entity);
-        Assertions.assertThrows(NullPointerException.class, () -> entity.key((TypeReference<Object>) null));
-    }
 
+        assertThatNullPointerException().isThrownBy(() -> entity.key((TypeReference<Object>) null)).withMessage("supplier is required");
+    }
 }

--- a/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/test/java/org/eclipse/jnosql/communication/keyvalue/KeyValueQueryParserTest.java
@@ -12,174 +12,199 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Elias Nogueira
  *
  */
 package org.eclipse.jnosql.communication.keyvalue;
 
 import jakarta.data.exceptions.NonUniqueResultException;
 import org.eclipse.jnosql.communication.Value;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class KeyValueQueryParserTest {
 
     private final KeyValueQueryParser parser = new KeyValueQueryParser();
 
-    private final BucketManager manager = Mockito.mock(BucketManager.class);
+    @Mock
+    private BucketManager manager;
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"get \"Diana\""})
-    public void shouldReturnParserQuery1(String query) {
+    @Captor
+    private ArgumentCaptor<List<Object>> captor;
 
-        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(List.class);
+    @Captor
+    private ArgumentCaptor<KeyValueEntity> captorValueEntity;
 
-        parser.query(query, manager).collect(Collectors.toList());
+    @Captor
+    private ArgumentCaptor<Duration> captorDuration;
 
-        Mockito.verify(manager).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+    @Captor
+    private ArgumentCaptor<Object> captorObject;
 
-        assertEquals(1, value.size());
-        assertThat(value).contains("Diana");
+    @Test
+    @DisplayName("Should parse query using 'get'")
+    void shouldReturnParserQuery1() {
+        String query = """
+                get "Diana"
+                """;
+
+        parser.query(query, manager).toList();
+
+        verify(manager).get(captorObject.capture());
+        List<Object> value = captorObject.getAllValues();
+
+        assertThat(value).containsExactly("Diana");
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"put {\"Diana\", \"Hunt\"}"})
-    public void shouldReturnParserQuery2(String query) {
-
-        ArgumentCaptor<KeyValueEntity> captor = ArgumentCaptor.forClass(KeyValueEntity.class);
-
+    @Test
+    @DisplayName("Should parse query using 'put'")
+    void shouldReturnParserQuery2() {
+        String query = """
+                put { "Diana", "Hunt" }
+                """;
         parser.query(query, manager);
 
-        Mockito.verify(manager).put(captor.capture());
-        KeyValueEntity entity = captor.getValue();
+        verify(manager).put(captorValueEntity.capture());
+        KeyValueEntity entity = captorValueEntity.getValue();
 
-        assertEquals("Diana", entity.key());
-        assertEquals("Hunt", entity.value());
+        assertSoftly(softly -> {
+            softly.assertThat(entity.key()).as("key is equal").isEqualTo("Diana");
+            softly.assertThat(entity.value()).as("entity is equal").isEqualTo("Hunt");
+        });
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del \"Diana\""})
-    public void shouldReturnParserQuery3(String query) {
-
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
-
+    @Test
+    @DisplayName("Should parse query using 'del'")
+    void shouldReturnParserQuery3() {
+        String query = """
+                del "Diana"
+                """;
         parser.query(query, manager);
 
-        Mockito.verify(manager).delete(captor.capture());
+        verify(manager).delete(captor.capture());
         List<Object> value = captor.getValue();
 
-        assertEquals(1, value.size());
-        assertThat(value).contains("Diana");
+        assertThat(value).hasSize(1).contains("Diana");
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"del @id"})
-    public void shouldExecutePrepareStatement(String query) {
-
-        ArgumentCaptor<List<Object>> captor = ArgumentCaptor.forClass(List.class);
-        KeyValuePreparedStatement prepare = parser.prepare(query, manager);
+    @Test
+    @DisplayName("Should execute prepared statement using 'del'")
+    void shouldExecutePrepareStatement() {
+        KeyValuePreparedStatement prepare = parser.prepare("del @id", manager);
         prepare.bind("id", 10);
         prepare.result();
 
-        Mockito.verify(manager).delete(captor.capture());
+        verify(manager).delete(captor.capture());
         List<Object> value = captor.getValue();
 
-        assertEquals(1, value.size());
-
-        assertThat(value).contains(10);
+        assertThat(value).hasSize(1).contains(10);
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"put {\"Diana\", @value}"})
-    public void shouldExecutePrepareStatement1(String query) {
+    @Test
+    @DisplayName("Should execute prepared statement using 'put'")
+    void shouldExecutePrepareStatement1() {
+        String query = """
+                put { "Diana", @value }
+                """;
         KeyValuePreparedStatement prepare = parser.prepare(query, manager);
         prepare.bind("value", "Hunt");
         prepare.result();
-        ArgumentCaptor<KeyValueEntity> captor = ArgumentCaptor.forClass(KeyValueEntity.class);
 
-        Mockito.verify(manager).put(captor.capture());
-        KeyValueEntity entity = captor.getValue();
+        verify(manager).put(captorValueEntity.capture());
+        KeyValueEntity entity = captorValueEntity.getValue();
 
-        assertEquals("Diana", entity.key());
-        assertEquals("Hunt", entity.value());
+        assertSoftly(softly -> {
+            softly.assertThat(entity.key()).as("key is equal").isEqualTo("Diana");
+            softly.assertThat(entity.value()).as("entity is equal").isEqualTo("Hunt");
+        });
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"put {\"Diana\", @value, 10 second}"})
-    public void shouldExecutePrepareStatement2(String query) {
+    @Test
+    @DisplayName("Should execute prepared statement using 'put' setting a value")
+    void shouldExecutePrepareStatement2() {
+        String query = """
+                put { "Diana", @value, 10 second }
+                """;
         KeyValuePreparedStatement prepare = parser.prepare(query, manager);
         prepare.bind("value", "Hunt");
         prepare.result();
-        ArgumentCaptor<KeyValueEntity> captor = ArgumentCaptor.forClass(KeyValueEntity.class);
-        ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
 
-        Mockito.verify(manager).put(captor.capture(), durationCaptor.capture());
-        KeyValueEntity entity = captor.getValue();
-        final Duration duration = durationCaptor.getValue();
+        verify(manager).put(captorValueEntity.capture(), captorDuration.capture());
+        KeyValueEntity entity = captorValueEntity.getValue();
+        final Duration duration = captorDuration.getValue();
 
-        assertEquals("Diana", entity.key());
-        assertEquals("Hunt", entity.value());
-        assertEquals(Duration.ofSeconds(10L), duration);
+        assertSoftly(softly -> {
+            softly.assertThat(entity.key()).as("key is equal").isEqualTo("Diana");
+            softly.assertThat(entity.value()).as("entity is equal").isEqualTo("Hunt");
+            softly.assertThat(duration).as("duration is equal").isEqualTo(Duration.ofSeconds(10L));
+        });
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"get @id"})
-    public void shouldReturnSingleResult(String query) {
+    @Test
+    @DisplayName("Should return a single result")
+    void shouldReturnSingleResult() {
+        String query = "get @id";
 
-        Mockito.when(manager.get(10)).thenReturn(Optional.of(Value.of(10L)));
-        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(List.class);
+        when(manager.get(10)).thenReturn(Optional.of(Value.of(10)));
+
         KeyValuePreparedStatement prepare = parser.prepare(query, manager);
         prepare.bind("id", 10);
         final Optional<Value> result = prepare.singleResult();
 
-        Mockito.verify(manager).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+        verify(manager).get(captorObject.capture());
+        List<Object> value = captorObject.getAllValues();
 
-        assertEquals(1, value.size());
-        assertThat(value).contains(10);
-        assertEquals(10L, result.get().get());
+        assertSoftly(softly -> {
+            softly.assertThat(value).as("key is equal").hasSize(1).contains(10);
+            softly.assertThat(result.get().get()).as("").isEqualTo(10);
+        });
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"get @id"})
-    public void shouldReturnEmptySingleResult(String query) {
+    @Test
+    @DisplayName("Should return an empty single result")
+    void shouldReturnEmptySingleResult() {
+        when(manager.get(10)).thenReturn(Optional.empty());
 
-        Mockito.when(manager.get(10)).thenReturn(Optional.empty());
-        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(List.class);
-        KeyValuePreparedStatement prepare = parser.prepare(query, manager);
+        KeyValuePreparedStatement prepare = parser.prepare("get @id", manager);
         prepare.bind("id", 10);
         final Optional<Value> result = prepare.singleResult();
 
-        Mockito.verify(manager).get(captor.capture());
-        List<Object> value = captor.getAllValues();
+        verify(manager).get(captorObject.capture());
+        List<Object> value = captorObject.getAllValues();
 
-        assertEquals(1, value.size());
-        assertThat(value).contains(10);
-        assertFalse(result.isPresent());
+        assertSoftly(softly -> {
+            softly.assertThat(value).as("key is equal").hasSize(1).contains(10);
+            softly.assertThat(result).as("result is present").isNotPresent();
+        });
     }
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"get @id, @id2"})
-    public void shouldReturnErrorSingleResult(String query) {
+    @Test
+    @DisplayName("Should throw NonUniqueResultException when get single result")
+    void shouldReturnErrorSingleResult() {
+        when(manager.get(10)).thenReturn(Optional.of(Value.of(10)));
+        when(manager.get(11)).thenReturn(Optional.of(Value.of(11)));
 
-        Mockito.when(manager.get(10)).thenReturn(Optional.of(Value.of(10)));
-        Mockito.when(manager.get(11)).thenReturn(Optional.of(Value.of(11)));
-        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(List.class);
-        KeyValuePreparedStatement prepare = parser.prepare(query, manager);
+        KeyValuePreparedStatement prepare = parser.prepare("get @id, @id2", manager);
         prepare.bind("id", 10);
         prepare.bind("id2", 11);
-        Assertions.assertThrows(NonUniqueResultException.class, prepare::singleResult);
+
+        assertThatThrownBy(prepare::singleResult).isInstanceOf(NonUniqueResultException.class)
+                .hasMessage("The select returns more than one entity, select: get @id, @id2");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <!-- testing libraries -->
         <junit.version>5.9.2</junit.version>
-        <mockito.verson>4.11.0</mockito.verson>
+        <mockito.verson>5.3.1</mockito.verson>
         <assertj.version>3.24.2</assertj.version>
         <awaitility.version>4.2.0</awaitility.version>
         <pi-test.version>1.12.0</pi-test.version>


### PR DESCRIPTION
### Changes

- Bump mockito to 5.3.0
- Using `assertArg` from mockito when possible
- Replaced static usage of mockito mocks with annotations
- Extended the tests using mockito with `@ExtendWith(MockitoExtension.class)`
- Replaced JUnit 5 assertion by AssertJ ones
- Changed the parameterized tests with only one data by normal tests
- Changed some switch expressions
