### PR TITLE
Add support for default method on repositories

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,11 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Enhance database supplier error message to use property instead of the enum name.
 - Fix convertion to/from entities when it is a record
 
+=== Added
+
+- Include support for default method interface
+- Add support for interfaces that is not repository
+
 == [1.0.0-b6] - 2023-03-11
 
 === Changed

--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/query/AbstractColumnRepositoryProxy.java
@@ -30,10 +30,10 @@ import java.lang.reflect.Method;
 /**
  * Template method to Repository proxy on column
  *
- * @param <T>  the entity type
+ * @param <T> the entity type
  * @param <K> the K entity
  */
-public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRepository implements InvocationHandler {
+public abstract class AbstractColumnRepositoryProxy<T, K> extends BaseColumnRepository implements InvocationHandler {
 
     protected abstract PageableRepository getRepository();
 
@@ -68,6 +68,9 @@ public abstract class AbstractColumnRepositoryProxy<T, K> extends  BaseColumnRep
             }
             case OBJECT_METHOD -> {
                 return method.invoke(this, args);
+            }
+            case DEFAULT_METHOD -> {
+                return InvocationHandler.invokeDefault(instance, method, args);
             }
             case ORDER_BY ->
                     throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -53,7 +53,10 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -748,6 +751,15 @@ public class ColumnRepositoryProxyTest {
         assertNull(personRepository.findByName("name"));
     }
 
+    @Test
+    public void shouldExecuteDefaultMethod() {
+        personRepository.partcionate("name");
+        ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
+        verify(template, Mockito.times(2)).singleResult(captor.capture());
+        List<ColumnQuery> values = captor.getAllValues();
+        assertThat(values).isNotNull().hasSize(2);
+    }
+
     interface PersonRepository extends PageableRepository<Person, Long> {
 
         List<Person> findByActiveTrue();
@@ -764,6 +776,15 @@ public class ColumnRepositoryProxyTest {
         Person findByNameNot(String name);
 
         Person findByNameNotEquals(String name);
+
+        default Map<Boolean, List<Person>> partcionate(String name){
+            Objects.requireNonNull(name, "name is required");
+
+            Map<Boolean, List<Person>> map = new HashMap<>();
+            map.put(true, List.of(findByName(name)));
+            map.put(false, List.of(findByNameNot(name)));
+            return map;
+        }
 
         void deleteByName(String name);
 

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -122,11 +122,6 @@ public class ColumnRepositoryProxyTest {
                 .withAge(20)
                 .withId(1L).build();
 
-        when(template.select(Mockito.any(ColumnQuery.class)))
-                .thenReturn(Stream.of(person));
-        when(template.singleResult(Mockito.any(ColumnQuery.class)))
-                .thenReturn(Optional.of(person));
-
         personRepository = (PersonRepository) Proxy.newProxyInstance(PersonRepository.class.getClassLoader(),
                 new Class[]{PersonRepository.class},
                 personHandler);
@@ -827,9 +822,15 @@ public class ColumnRepositoryProxyTest {
         default Map<Boolean, List<Person>> partcionate(String name) {
             Objects.requireNonNull(name, "name is required");
 
+            var person = Person.builder()
+                    .withName("Ada Lovelace")
+                    .withAge(20)
+                    .withId(1L).build();
+            findByName(name);
+            findByNameNot(name);
             Map<Boolean, List<Person>> map = new HashMap<>();
-            map.put(true, List.of(findByName(name)));
-            map.put(false, List.of(findByNameNot(name)));
+            map.put(true, List.of(person));
+            map.put(false, List.of(person));
             return map;
         }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -68,7 +68,7 @@ public enum RepositoryType {
      */
     ORDER_BY(""),
     /**
-     *
+     * The method that belongs to the interface using a default method.
      */
     DEFAULT_METHOD("");
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/query/RepositoryType.java
@@ -66,7 +66,11 @@ public enum RepositoryType {
     /**
      * Method that has {@link jakarta.data.repository.OrderBy} annotation
      */
-    ORDER_BY("");
+    ORDER_BY(""),
+    /**
+     *
+     */
+    DEFAULT_METHOD("");
 
     private static final Predicate<Class<?>> IS_REPOSITORY_METHOD = Predicate.<Class<?>>isEqual(CrudRepository.class)
             .or(Predicate.isEqual(PageableRepository.class));
@@ -88,6 +92,9 @@ public enum RepositoryType {
     public static RepositoryType of(Method method) {
         Objects.requireNonNull(method, "method is required");
         Class<?> declaringClass = method.getDeclaringClass();
+        if (method.isDefault()) {
+            return DEFAULT_METHOD;
+        }
         if (Object.class.equals(declaringClass)) {
             return OBJECT_METHOD;
         }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/query/RepositoryTypeTest.java
@@ -89,6 +89,11 @@ class RepositoryTypeTest {
                 "order2")));
     }
 
+    @Test
+    public void shouldDefaultMethod() throws NoSuchMethodException {
+        Assertions.assertEquals(RepositoryType.DEFAULT_METHOD, RepositoryType.of(getMethod(DevRepository.class,
+                "duplicate")));
+    }
     private Method getMethod(Class<?> repository, String methodName) throws NoSuchMethodException {
         return Stream.of(repository.getDeclaredMethods())
                 .filter(m -> m.getName().equals(methodName))
@@ -119,6 +124,10 @@ class RepositoryTypeTest {
         @OrderBy("sample")
         @OrderBy("test")
         String order2();
+
+        default int duplicate(int value) {
+            return value * 2;
+        }
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/query/AbstractDocumentRepositoryProxy.java
@@ -68,6 +68,9 @@ public abstract class AbstractDocumentRepositoryProxy<T> extends BaseDocumentRep
             case OBJECT_METHOD -> {
                 return method.invoke(this, args);
             }
+            case DEFAULT_METHOD -> {
+                return InvocationHandler.invokeDefault(instance, method, args);
+            }
             case ORDER_BY ->
                     throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case QUERY -> {

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -675,7 +675,7 @@ public class DocumentCrudRepositoryProxyTest {
         personRepository.findByNameNot("Otavio");
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
-        verify(template).select(captor.capture());
+        verify(template).singleResult(captor.capture());
         DocumentQuery query = captor.getValue();
         DocumentCondition negate = query.condition().get();
         assertEquals(Condition.NOT, negate.condition());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -804,7 +804,7 @@ public class DocumentCrudRepositoryProxyTest {
 
         Person findByName(String name);
 
-        List<Person> findByNameNot(String name);
+        Person findByNameNot(String name);
 
         List<Person> findByNameNotEquals(String name);
 

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/query/AbstractGraphRepositoryProxy.java
@@ -88,6 +88,9 @@ abstract class AbstractGraphRepositoryProxy<T, K> implements InvocationHandler {
             case EXISTS_BY -> {
                 return existsBy(method, args);
             }
+            case DEFAULT_METHOD -> {
+                return InvocationHandler.invokeDefault(instance, method, args);
+            }
             case ORDER_BY ->
                     throw new MappingException("Eclipse JNoSQL has not support for method that has OrderBy annotation");
             case QUERY -> {

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -481,39 +481,53 @@ public class GraphRepositoryProxyTest {
 
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false);
-        graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", false);
-        graph.addVertex(T.label, "Person", "name", "Otavio", "age", 15, "active", false);
 
-        Map<Boolean, List<Person>> partcionate = personRepository.partcionate("name");
+        Map<Boolean, List<Person>> partcionate = personRepository.partcionate("Otavio");
 
         assertThat(partcionate).isNotEmpty().hasSize(2);
         List<Person> otavios = partcionate.get(true);
         List<Person> notOtavios = partcionate.get(false);
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(otavios).isNotEmpty().hasSize(2);
-            soft.assertThat(notOtavios).isNotEmpty().hasSize(2);
+            soft.assertThat(otavios).isNotEmpty().hasSize(1)
+                    .map(Person::getName).contains("Otavio");
+            soft.assertThat(notOtavios).isNotEmpty().hasSize(1)
+                    .map(Person::getName).contains("Poliana");
         });
     }
 
     @Test
     public void shouldUseQueriesFromOtherInterface() {
-        personRepository.findByNameLessThan("name");
 
+        graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false, "score", 2);
+        graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false, "score", 12);
+        graph.addVertex(T.label, "Person", "name", "Ada", "age", 4, "active", false, "score", 5);
+        graph.addVertex(T.label, "Person", "name", "Elias", "age", 20, "active", false, "score", 15);
+        List<Person> people = personRepository.findByScoreLessThan(14);
+        assertThat(people).isNotEmpty().hasSize(3)
+                .map(Person::getName)
+                        .contains("Otavio","Ada", "Poliana");
     }
 
     @Test
     public void shouldUseDefaultMethodFromOtherInterface() {
-        personRepository.ada();
 
+        graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false, "score", 2);
+        graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false, "score", 12);
+        graph.addVertex(T.label, "Person", "name", "Ada", "age", 4, "active", false, "score", 5);
+        graph.addVertex(T.label, "Person", "name", "Elias", "age", 20, "active", false, "score", 15);
+        List<Person> people =  personRepository.lessThanTen();
+        assertThat(people).isNotEmpty().hasSize(2)
+                .map(Person::getName)
+                .contains("Otavio","Ada");
 
     }
 
     interface BaseQuery<T> {
 
-        List<T> findByNameLessThan(String name);
+        List<T> findByScoreLessThan(int value);
 
-        default List<T> ada() {
-            return this.findByNameLessThan("Ada");
+        default List<T> lessThanTen() {
+            return this.findByScoreLessThan(10);
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/AbstractKeyValueRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/AbstractKeyValueRepositoryProxy.java
@@ -44,6 +44,9 @@ public abstract class AbstractKeyValueRepositoryProxy<T> implements InvocationHa
             case OBJECT_METHOD -> {
                 return method.invoke(this, args);
             }
+            case DEFAULT_METHOD -> {
+                return InvocationHandler.invokeDefault(instance, method, args);
+            }
             case QUERY -> {
                 Class<?> typeClass = getType();
                 DynamicQueryMethodReturn methodReturn = DynamicQueryMethodReturn.builder()

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProxyTest.java
@@ -143,6 +143,27 @@ public class KeyValueRepositoryProxyTest {
     }
 
     @Test
+    public void shouldExecuteDefaultMethod() {
+        User user = new User("12", "Ada", 10);
+        when(repository.query("get \"otavio\"", User.class)).thenReturn(Stream.of(user));
+        userRepository.otavio();
+        verify(repository).prepare("get \"otavio\"", User.class);
+    }
+
+    @Test
+    public void shouldUseQueriesFromOtherInterface() {
+        User user = new User("12", "Ada", 10);
+        when(repository.query("get \"otavio\"", User.class)).thenReturn(Stream.of(user));
+        userRepository.otavio();
+        verify(repository).prepare("get \"otavio\"", User.class);
+    }
+
+    @Test
+    public void shouldUseDefaultMethodFromOtherInterface() {
+
+    }
+
+    @Test
     public void shouldReturnErrorWhenExecuteMethodQuery() {
         Assertions.assertThrows(DynamicQueryException.class, () -> userRepository.findByName("name"));
     }
@@ -157,12 +178,29 @@ public class KeyValueRepositoryProxyTest {
         assertEquals(userRepository.hashCode(), userRepository.hashCode());
     }
 
-    interface UserRepository extends PageableRepository<User, String> {
+    interface BaseQuery<T> {
+
+        @Query("get @key ")
+        List<T> key(@Param("key") String name);
+
+        default List<T> ada() {
+            return this.key("Ada");
+        }
+    }
+
+    interface UserRepository extends PageableRepository<User, String>, BaseQuery<User> {
 
         Optional<User> findByName(String name);
 
         @Query("get \"12\"")
         Optional<User> findByQuery();
+
+
+        @Query("get @id")
+        Optional<User> querybyKey(@Param("id") String key);
+        default Optional<User> otavio() {
+            return querybyKey("otavio");
+        }
 
         @Query("get @id")
         Optional<User> findByQuery(@Param("id") String id);


### PR DESCRIPTION
# Changes

Add support for default methods on an interface and also extra interface:

```java
  interface BaseQuery<T> {

        List<T> findByScoreLessThan(int score);

        default List<T> lessTen() {
            return this.findByScoreLessThan(10);
        }
    }

@Repository    
interface PersonRepository extends PageableRepository<Person, Long>, BaseQuery<Person> {

   List<Person> findByName(String name);

   List<Person> findByNameNot(String name);

default Map<Boolean, List<Person>> partcionate(String name) {

            Objects.requireNonNull(name, "name is required");
            Map<Boolean, List<Person>> map = new HashMap<>();
            map.put(true,  findByName(name));
            map.put(false, findByNameNot(name));
            return map;
        }
}

@Repository    
interface Garage extends PageableRepository<Car, Long>, BaseQuery<Car> {
}
```

So, the project will support both:


```java
@Inject
Garage garage;

@Inject
PersonRepository repository;


List<Person> people = repository.findByScoreLessThan(14);
List<Car> cars = garage.findByScoreLessThan(14);
Map<Boolean, List<Person>> parcionate = repository.partcionate("Otaviojava");
....

```

Implements this issue:
https://github.com/jakartaee/data/issues/148