### PR TITLE
Field name auto-detection when given a constructor parameters of Record classes are annotated with @Column defined with empty name.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Create a filter to ignore unsupported annotations on repositories interfaces.
 - Enhance database supplier error message to use property instead of the enum name.
 - Fix convertion to/from entities when it is a record
+- Enhance the field name auto-detection of the constructor parameters annotated with @Column defined with empty name when it's used Record as entity
 
 === Added
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilder.java
@@ -19,6 +19,7 @@ import jakarta.nosql.Id;
 import org.eclipse.jnosql.mapping.Convert;
 
 import java.lang.reflect.Parameter;
+import java.util.Objects;
 import java.util.Optional;
 
 class ParameterMetaDataBuilder {
@@ -37,6 +38,10 @@ class ParameterMetaDataBuilder {
         String name = Optional.ofNullable(id)
                 .map(Id::value)
                 .orElseGet(() -> column.value());
+        if ((Objects.isNull(name) || name.isBlank())
+                && parameter.getDeclaringExecutable().getDeclaringClass().isRecord()) {
+            name = parameter.getName();
+        }
         MappingType mappingType = MappingType.of(parameter);
         return switch (mappingType) {
             case COLLECTION, MAP -> new GenericParameterMetaData(name, type,

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassScannerTest.java
@@ -38,7 +38,7 @@ class ClassScannerTest {
     public void shouldReturnEntities() {
         Set<Class<?>> entities = classScanner.entities();
         Assertions.assertNotNull(entities);
-        assertThat(entities).hasSize(24)
+        assertThat(entities).hasSize(25)
                 .contains(Person.class);
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ConstructorMetadataBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ConstructorMetadataBuilderTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jnosql.mapping.test.entities.Worker;
 import org.eclipse.jnosql.mapping.test.entities.constructor.Computer;
 import org.eclipse.jnosql.mapping.test.entities.constructor.BookUser;
 import org.eclipse.jnosql.mapping.test.entities.constructor.PetOwner;
+import org.eclipse.jnosql.mapping.test.entities.constructor.Smartphone;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
@@ -87,6 +88,18 @@ class ConstructorMetadataBuilderTest {
                 .toList();
 
         assertThat(names).contains("_id", "native_name", "books");
+    }
+
+    @Test
+    public void shouldReturnSmartphoneEntityConstructor() {
+        ConstructorMetadata metadata = builder.build(Smartphone.class);
+        List<ParameterMetaData> parameters = metadata.getParameters();
+        assertEquals(2, parameters.size());
+        List<String> names = parameters.stream()
+                .map(ParameterMetaData::getName)
+                .toList();
+
+        assertThat(names).contains("_id", "owner");
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilderTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jnosql.mapping.test.entities.MoneyConverter;
 import org.eclipse.jnosql.mapping.test.entities.constructor.Computer;
 import org.eclipse.jnosql.mapping.test.entities.constructor.PetOwner;
 import org.eclipse.jnosql.mapping.test.entities.constructor.BookUser;
+import org.eclipse.jnosql.mapping.test.entities.constructor.Smartphone;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,18 @@ class ParameterMetaDataBuilderTest {
         Assertions.assertEquals(Long.class, id.getType());
         Assertions.assertEquals(MappingType.DEFAULT, id.getParamType());
         Assertions.assertTrue(id.getConverter().isEmpty());
+    }
+
+    @Test
+    public void shouldConvertDefaultParameterWithoutDefinedName() {
+        Constructor<Smartphone> constructor = (Constructor<Smartphone>) Smartphone.class.getDeclaredConstructors()[0];
+        ParameterMetaData name = ParameterMetaDataBuilder.of(constructor.getParameters()[1]);
+        Assertions.assertNotNull(name);
+        Assertions.assertFalse(name.isId());
+        Assertions.assertEquals("owner", name.getName());
+        Assertions.assertEquals(String.class, name.getType());
+        Assertions.assertEquals(MappingType.DEFAULT, name.getParamType());
+        Assertions.assertTrue(name.getConverter().isEmpty());
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Smartphone.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Smartphone.java
@@ -1,0 +1,24 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License v1.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.mapping.test.entities.constructor;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+@Entity
+public record Smartphone(@Id String id, @Column String owner) {
+}


### PR DESCRIPTION
## Changes

- Enhance the field name auto-detection when given constructor parameters of Record classes are annotated with `@Column` defined with an empty name.

## Why this change is important?

It will improve the dev experience, allowing developers to use Records with fields annotated with `@Column` without the necessity to provide a given column name;