### PR TITLE
docs: fixing jnosql extensions url

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -19,7 +19,7 @@ The project maintains the following source code repositories
 
 * https://github.com/eclipse/jnosql
 * https://github.com/eclipse/jnosql-databases
-* https://github.com/eclipse/jnosql-extension
+* https://github.com/eclipse/jnosql-extensions
 
 == Eclipse Contributor Agreement
 


### PR DESCRIPTION
My change suggestion is about `docs`:

1. The jnosql-extension repo URL is wrong.

Thank you.