### PR TITLE
refact: unecessary matcher

### DIFF
--- a/jnosql-communication/jnosql-communication-document/src/main/java/org/eclipse/jnosql/communication/document/SelectQueryParser.java
+++ b/jnosql-communication/jnosql-communication-document/src/main/java/org/eclipse/jnosql/communication/document/SelectQueryParser.java
@@ -101,8 +101,7 @@ public final class SelectQueryParser implements BiFunction<SelectQuery, Document
     }
 
     private Sort toSort(Sort sort, DocumentObserverParser observer, String entity) {
-        return Sort.of(observer.fireField(entity, sort.property()),
-                sort.isAscending() == true ? Direction.ASC : Direction.DESC, false);
+        return Sort.of(observer.fireField(entity, sort.property()), sort.isAscending() ? Direction.ASC : Direction.DESC, false);
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/MapperSelectTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/MapperSelectTest.java
@@ -296,7 +296,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         List<Person> result = template.select(Person.class).result();
         Assertions.assertNotNull(result);
         assertThat(result).hasSize(1)
@@ -312,7 +312,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         Stream<Person> result = template.select(Person.class).stream();
         Assertions.assertNotNull(result);
     }
@@ -325,7 +325,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         Optional<Person> result = template.select(Person.class).singleResult();
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.isPresent());

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/MapperSelectTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/MapperSelectTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, ColumnWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, ColumnExtension.class})
-public class MapperSelectTest {
+class MapperSelectTest {
 
     @Inject
     private ColumnEntityConverter converter;
@@ -83,7 +83,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldExecuteSelectFrom() {
+    void shouldExecuteSelectFrom() {
         template.select(Person.class).result();
         ColumnQuery queryExpected = select().from("Person").build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -92,7 +92,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectOrderAsc() {
+    void shouldSelectOrderAsc() {
         template.select(Worker.class).orderBy("salary").asc().result();
         Mockito.verify(managerMock).select(captor.capture());
         ColumnQuery query = captor.getValue();
@@ -101,7 +101,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectOrderDesc() {
+    void shouldSelectOrderDesc() {
         template.select(Worker.class).orderBy("salary").desc().result();
         ColumnQuery queryExpected = select().from("Worker").orderBy("money").desc().build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -110,7 +110,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectLimit() {
+    void shouldSelectLimit() {
         template.select(Worker.class).limit(10).result();
         ColumnQuery queryExpected = select().from("Worker").limit(10L).build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -119,7 +119,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectStart() {
+    void shouldSelectStart() {
         template.select(Worker.class).skip(10).result();
         ColumnQuery queryExpected = select().from("Worker").skip(10L).build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -129,7 +129,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereEq() {
+    void shouldSelectWhereEq() {
         template.select(Person.class).where("name").eq("Ada").result();
         ColumnQuery queryExpected = select().from("Person").where("name")
                 .eq("Ada").build();
@@ -139,7 +139,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereLike() {
+    void shouldSelectWhereLike() {
         template.select(Person.class).where("name").like("Ada").result();
         ColumnQuery queryExpected = select().from("Person").where("name")
                 .like("Ada").build();
@@ -149,7 +149,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereGt() {
+    void shouldSelectWhereGt() {
         template.select(Person.class).where("id").gt(10).result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
                 .gt(10L).build();
@@ -159,7 +159,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereGte() {
+    void shouldSelectWhereGte() {
         template.select(Person.class).where("id").gte(10).result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
                 .gte(10L).build();
@@ -170,7 +170,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereLt() {
+    void shouldSelectWhereLt() {
         template.select(Person.class).where("id").lt(10).result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
                 .lt(10L).build();
@@ -180,7 +180,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereLte() {
+    void shouldSelectWhereLte() {
         template.select(Person.class).where("id").lte(10).result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
                 .lte(10L).build();
@@ -190,7 +190,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereBetween() {
+    void shouldSelectWhereBetween() {
         template.select(Person.class).where("id")
                 .between(10, 20).result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
@@ -201,7 +201,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereNot() {
+    void shouldSelectWhereNot() {
         template.select(Person.class).where("name").not().like("Ada").result();
         ColumnQuery queryExpected = select().from("Person").where("name")
                 .not().like("Ada").build();
@@ -212,7 +212,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereAnd() {
+    void shouldSelectWhereAnd() {
         template.select(Person.class).where("age").between(10, 20)
                 .and("name").eq("Ada").result();
         ColumnQuery queryExpected = select().from("Person").where("age")
@@ -225,7 +225,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereOr() {
+    void shouldSelectWhereOr() {
         template.select(Person.class).where("id").between(10, 20)
                 .or("name").eq("Ada").result();
         ColumnQuery queryExpected = select().from("Person").where("_id")
@@ -238,7 +238,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldConvertField() {
+    void shouldConvertField() {
         template.select(Person.class).where("id").eq("20")
                 .result();
         ColumnQuery queryExpected = select().from("Person").where("_id").eq(20L)
@@ -251,7 +251,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldUseAttributeConverter() {
+    void shouldUseAttributeConverter() {
         template.select(Worker.class).where("salary")
                 .eq(new Money("USD", BigDecimal.TEN)).result();
         ColumnQuery queryExpected = select().from("Worker").where("money")
@@ -263,7 +263,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldQueryByEmbeddable() {
+    void shouldQueryByEmbeddable() {
         template.select(Worker.class).where("job.city").eq("Salvador")
                 .result();
         ColumnQuery queryExpected = select().from("Worker").where("city")
@@ -276,7 +276,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldQueryBySubEntity() {
+    void shouldQueryBySubEntity() {
         template.select(Address.class).where("zipCode.zip").eq("01312321")
                 .result();
         ColumnQuery queryExpected = select().from("Address").where("zipCode.zip")
@@ -290,7 +290,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldResult() {
+    void shouldResult() {
         ColumnQuery query = select().from("Person").build();
         ColumnEntity entity = ColumnEntity.of("Person");
         entity.add("_id", 1L);
@@ -305,7 +305,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldStream() {
+    void shouldStream() {
 
         ColumnQuery query = select().from("Person").build();
         ColumnEntity entity = ColumnEntity.of("Person");
@@ -318,7 +318,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSingleResult() {
+    void shouldSingleResult() {
 
         ColumnQuery query = select().from("Person").build();
         ColumnEntity entity = ColumnEntity.of("Person");
@@ -332,7 +332,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldReturnErrorSelectWhenOrderIsNull() {
+    void shouldReturnErrorSelectWhenOrderIsNull() {
         Assertions.assertThrows(NullPointerException.class, () -> template.select(Worker.class).orderBy(null));
     }
 

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
@@ -282,7 +282,7 @@ class ColumnCrudRepositoryProxyTest {
     @Test
     void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
     }
 
     @Test
@@ -291,7 +291,7 @@ class ColumnCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
 
         personRepository.findAllById(asList(1L, 2L, 3L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), Mockito.any(Long.class));

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
@@ -282,7 +282,7 @@ public class ColumnCrudRepositoryProxyTest {
     @Test
     public void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
@@ -291,7 +291,7 @@ public class ColumnCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
 
         personRepository.findAllById(asList(1L, 2L, 3L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), Mockito.any(Long.class));

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnCrudRepositoryProxyTest.java
@@ -85,7 +85,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, ColumnWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, ColumnExtension.class})
-public class ColumnCrudRepositoryProxyTest {
+class ColumnCrudRepositoryProxyTest {
 
     private JNoSQLColumnTemplate template;
 
@@ -132,7 +132,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Person.class, 10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -148,7 +148,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
 
         when(template.find(Person.class, 10L)).thenReturn(Optional.of(Person.builder().build()));
 
@@ -165,7 +165,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -182,7 +182,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         when(template.singleResult(any(ColumnQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -207,7 +207,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAge() {
+    void shouldFindByNameANDAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -222,7 +222,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeANDName() {
+    void shouldFindByAgeANDName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -237,7 +237,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByName() {
+    void shouldFindByNameANDAgeOrderByName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -252,7 +252,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByAge() {
+    void shouldFindByNameANDAgeOrderByAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -267,7 +267,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteByName("Ada");
         verify(template).delete(captor.capture());
@@ -280,13 +280,13 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         personRepository.findById(10L);
         verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -298,14 +298,14 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteById(10L);
         verify(template).delete(Person.class, 10L);
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(Person.class, 10L);
@@ -313,7 +313,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(Person.class, 10L)).thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
@@ -325,7 +325,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -340,7 +340,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         ArgumentCaptor<Class<?>> captor = ArgumentCaptor.forClass(Class.class);
         verify(template).deleteAll(captor.capture());
@@ -349,17 +349,17 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterEqualThan() {
+    void shouldFindByNameAndAgeGreaterEqualThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -388,7 +388,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByGreaterThan() {
+    void shouldFindByGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -407,7 +407,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessThanEqual() {
+    void shouldFindByAgeLessThanEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -426,7 +426,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessEqual() {
+    void shouldFindByAgeLessEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -445,7 +445,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeBetween() {
+    void shouldFindByAgeBetween() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -467,7 +467,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameLike() {
+    void shouldFindByNameLike() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -487,7 +487,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -507,7 +507,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -527,7 +527,7 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldConvertFieldToTheType() {
+    void shouldConvertFieldToTheType() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -546,13 +546,13 @@ public class ColumnCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldExecuteJNoSQLQuery() {
+    void shouldExecuteJNoSQLQuery() {
         personRepository.findByQuery();
         verify(template).query("select * from Person");
     }
 
     @Test
-    public void shouldExecuteJNoSQLPrepare() {
+    void shouldExecuteJNoSQLPrepare() {
         PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString())).thenReturn(statement);
         personRepository.findByQuery("Ada");
@@ -560,7 +560,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_Currency() {
+    void shouldFindBySalary_Currency() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -579,7 +579,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyAndSalary_Value() {
+    void shouldFindBySalary_CurrencyAndSalary_Value() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
         when(template.select(any(ColumnQuery.class)))
@@ -600,7 +600,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
+    void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -621,7 +621,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNotEquals() {
+    void shouldFindByNameNotEquals() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -641,7 +641,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeNotGreaterThan() {
+    void shouldFindByAgeNotGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -661,7 +661,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldConvertMapAddressRepository() {
+    void shouldConvertMapAddressRepository() {
 
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
         addressRepository.findByZipCodeZip("123456");
@@ -682,7 +682,7 @@ public class ColumnCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldConvertMapAddressRepositoryOrder() {
+    void shouldConvertMapAddressRepositoryOrder() {
 
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
         addressRepository.findByZipCodeZipOrderByZipCodeZip("123456");

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, ColumnWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, ColumnExtension.class})
-public class ColumnRepositoryProxyTest {
+class ColumnRepositoryProxyTest {
 
     private JNoSQLColumnTemplate template;
 
@@ -131,7 +131,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Person.class, 10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -147,7 +147,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
 
         when(template.find(Person.class, 10L)).thenReturn(Optional.of(Person.builder().build()));
 
@@ -164,7 +164,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -181,7 +181,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         when(template.singleResult(any(ColumnQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -206,7 +206,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAge() {
+    void shouldFindByNameANDAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -221,7 +221,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeANDName() {
+    void shouldFindByAgeANDName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -236,7 +236,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByName() {
+    void shouldFindByNameANDAgeOrderByName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -251,7 +251,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByAge() {
+    void shouldFindByNameANDAgeOrderByAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -266,7 +266,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteByName("Ada");
         verify(template).delete(captor.capture());
@@ -279,13 +279,13 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         personRepository.findById(10L);
         verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -297,14 +297,14 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteById(10L);
         verify(template).delete(Person.class, 10L);
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(Person.class, 10L);
@@ -312,7 +312,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(Person.class, 10L)).thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
@@ -324,7 +324,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -339,7 +339,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         ArgumentCaptor<Class<?>> captor = ArgumentCaptor.forClass(Class.class);
         verify(template).deleteAll(captor.capture());
@@ -348,23 +348,23 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertNotNull(personRepository.hashCode());
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldReturnEquals() {
+    void shouldReturnEquals() {
         assertNotNull(personRepository.equals(personRepository));
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterEqualThan() {
+    void shouldFindByNameAndAgeGreaterEqualThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -393,7 +393,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByGreaterThan() {
+    void shouldFindByGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -412,7 +412,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessThanEqual() {
+    void shouldFindByAgeLessThanEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -431,7 +431,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessEqual() {
+    void shouldFindByAgeLessEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -450,7 +450,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeBetween() {
+    void shouldFindByAgeBetween() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -472,7 +472,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameLike() {
+    void shouldFindByNameLike() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -491,20 +491,20 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldGotOrderException() {
+    void shouldGotOrderException() {
         Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findBy());
     }
 
     @Test
-    public void shouldGotOrderException2() {
+    void shouldGotOrderException2() {
         Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findByException());
     }
 
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -524,7 +524,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -544,7 +544,7 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldConvertFieldToTheType() {
+    void shouldConvertFieldToTheType() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -562,7 +562,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveTrue() {
+    void shouldFindByActiveTrue() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -580,7 +580,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveFalse() {
+    void shouldFindByActiveFalse() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -599,13 +599,13 @@ public class ColumnRepositoryProxyTest {
 
 
     @Test
-    public void shouldExecuteJNoSQLQuery() {
+    void shouldExecuteJNoSQLQuery() {
         personRepository.findByQuery();
         verify(template).query("select * from Person");
     }
 
     @Test
-    public void shouldExecuteJNoSQLPrepare() {
+    void shouldExecuteJNoSQLPrepare() {
         PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString())).thenReturn(statement);
         personRepository.findByQuery("Ada");
@@ -613,7 +613,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_Currency() {
+    void shouldFindBySalary_Currency() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -632,7 +632,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyAndSalary_Value() {
+    void shouldFindBySalary_CurrencyAndSalary_Value() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
         when(template.select(any(ColumnQuery.class)))
@@ -653,7 +653,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
+    void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -673,7 +673,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldCountByName() {
+    void shouldCountByName() {
         when(template.count(any(ColumnQuery.class)))
                 .thenReturn(10L);
 
@@ -690,7 +690,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExistsByName() {
+    void shouldExistsByName() {
         when(template.exists(any(ColumnQuery.class)))
                 .thenReturn(true);
 
@@ -707,7 +707,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNot() {
+    void shouldFindByNameNot() {
 
         when(template.singleResult(any(ColumnQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -732,7 +732,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNotEquals() {
+    void shouldFindByNameNotEquals() {
 
         when(template.singleResult(any(ColumnQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -757,7 +757,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExecuteDefaultMethod() {
+    void shouldExecuteDefaultMethod() {
         personRepository.partcionate("name");
 
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
@@ -767,7 +767,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseQueriesFromOtherInterface() {
+    void shouldUseQueriesFromOtherInterface() {
         personRepository.findByNameLessThan("name");
 
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
@@ -780,7 +780,7 @@ public class ColumnRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseDefaultMethodFromOtherInterface() {
+    void shouldUseDefaultMethodFromOtherInterface() {
         personRepository.ada();
 
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -281,7 +281,7 @@ class ColumnRepositoryProxyTest {
     @Test
     void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
     }
 
     @Test
@@ -290,7 +290,7 @@ class ColumnRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
 
         personRepository.findAllById(asList(1L, 2L, 3L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), Mockito.any(Long.class));

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -281,7 +281,7 @@ public class ColumnRepositoryProxyTest {
     @Test
     public void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
@@ -290,7 +290,7 @@ public class ColumnRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
 
         personRepository.findAllById(asList(1L, 2L, 3L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), Mockito.any(Long.class));

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/MapperSelectTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/MapperSelectTest.java
@@ -296,7 +296,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         List<Person> result = template.select(Person.class).result();
         Assertions.assertNotNull(result);
         assertThat(result).hasSize(1)
@@ -312,7 +312,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         Stream<Person> result = template.select(Person.class).stream();
         Assertions.assertNotNull(result);
     }
@@ -325,7 +325,7 @@ public class MapperSelectTest {
         entity.add("_id", 1L);
         entity.add("name", "Ada");
         entity.add("age", 20);
-        Mockito.when(managerMock.select(Mockito.eq(query))).thenReturn(Stream.of(entity));
+        Mockito.when(managerMock.select(query)).thenReturn(Stream.of(entity));
         Optional<Person> result = template.select(Person.class).singleResult();
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.isPresent());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/MapperSelectTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/MapperSelectTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, DocumentWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, DocumentExtension.class})
-public class MapperSelectTest {
+class MapperSelectTest {
 
     @Inject
     private DocumentEntityConverter converter;
@@ -83,7 +83,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldExecuteSelectFrom() {
+    void shouldExecuteSelectFrom() {
         template.select(Person.class).result();
         DocumentQuery queryExpected = select().from("Person").build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -92,7 +92,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectOrderAsc() {
+    void shouldSelectOrderAsc() {
         template.select(Worker.class).orderBy("salary").asc().result();
         Mockito.verify(managerMock).select(captor.capture());
         DocumentQuery query = captor.getValue();
@@ -101,7 +101,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectOrderDesc() {
+    void shouldSelectOrderDesc() {
         template.select(Worker.class).orderBy("salary").desc().result();
         DocumentQuery queryExpected = select().from("Worker").orderBy("money").desc().build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -110,7 +110,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectLimit() {
+    void shouldSelectLimit() {
         template.select(Worker.class).limit(10).result();
         DocumentQuery queryExpected = select().from("Worker").limit(10L).build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -119,7 +119,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectStart() {
+    void shouldSelectStart() {
         template.select(Worker.class).skip(10).result();
         DocumentQuery queryExpected = select().from("Worker").skip(10L).build();
         Mockito.verify(managerMock).select(captor.capture());
@@ -129,7 +129,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereEq() {
+    void shouldSelectWhereEq() {
         template.select(Person.class).where("name").eq("Ada").result();
         DocumentQuery queryExpected = select().from("Person").where("name")
                 .eq("Ada").build();
@@ -139,7 +139,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereLike() {
+    void shouldSelectWhereLike() {
         template.select(Person.class).where("name").like("Ada").result();
         DocumentQuery queryExpected = select().from("Person").where("name")
                 .like("Ada").build();
@@ -149,7 +149,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereGt() {
+    void shouldSelectWhereGt() {
         template.select(Person.class).where("id").gt(10).result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
                 .gt(10L).build();
@@ -159,7 +159,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereGte() {
+    void shouldSelectWhereGte() {
         template.select(Person.class).where("id").gte(10).result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
                 .gte(10L).build();
@@ -170,7 +170,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereLt() {
+    void shouldSelectWhereLt() {
         template.select(Person.class).where("id").lt(10).result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
                 .lt(10L).build();
@@ -180,7 +180,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereLte() {
+    void shouldSelectWhereLte() {
         template.select(Person.class).where("id").lte(10).result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
                 .lte(10L).build();
@@ -190,7 +190,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereBetween() {
+    void shouldSelectWhereBetween() {
         template.select(Person.class).where("id")
                 .between(10, 20).result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
@@ -201,7 +201,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereNot() {
+    void shouldSelectWhereNot() {
         template.select(Person.class).where("name").not().like("Ada").result();
         DocumentQuery queryExpected = select().from("Person").where("name")
                 .not().like("Ada").build();
@@ -212,7 +212,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldSelectWhereAnd() {
+    void shouldSelectWhereAnd() {
         template.select(Person.class).where("age").between(10, 20)
                 .and("name").eq("Ada").result();
         DocumentQuery queryExpected = select().from("Person").where("age")
@@ -225,7 +225,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSelectWhereOr() {
+    void shouldSelectWhereOr() {
         template.select(Person.class).where("id").between(10, 20)
                 .or("name").eq("Ada").result();
         DocumentQuery queryExpected = select().from("Person").where("_id")
@@ -238,7 +238,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldConvertField() {
+    void shouldConvertField() {
         template.select(Person.class).where("id").eq("20")
                 .result();
         DocumentQuery queryExpected = select().from("Person").where("_id").eq(20L)
@@ -251,7 +251,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldUseAttributeConverter() {
+    void shouldUseAttributeConverter() {
         template.select(Worker.class).where("salary")
                 .eq(new Money("USD", BigDecimal.TEN)).result();
         DocumentQuery queryExpected = select().from("Worker").where("money")
@@ -263,7 +263,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldQueryByEmbeddable() {
+    void shouldQueryByEmbeddable() {
         template.select(Worker.class).where("job.city").eq("Salvador")
                 .result();
         DocumentQuery queryExpected = select().from("Worker").where("city")
@@ -276,7 +276,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldQueryBySubEntity() {
+    void shouldQueryBySubEntity() {
         template.select(Address.class).where("zipCode.zip").eq("01312321")
                 .result();
         DocumentQuery queryExpected = select().from("Address").where("zipCode.zip")
@@ -290,7 +290,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldResult() {
+    void shouldResult() {
         DocumentQuery query = select().from("Person").build();
         DocumentEntity entity = DocumentEntity.of("Person");
         entity.add("_id", 1L);
@@ -305,7 +305,7 @@ public class MapperSelectTest {
 
 
     @Test
-    public void shouldStream() {
+    void shouldStream() {
 
         DocumentQuery query = select().from("Person").build();
         DocumentEntity entity = DocumentEntity.of("Person");
@@ -318,7 +318,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldSingleResult() {
+    void shouldSingleResult() {
 
         DocumentQuery query = select().from("Person").build();
         DocumentEntity entity = DocumentEntity.of("Person");
@@ -332,7 +332,7 @@ public class MapperSelectTest {
     }
 
     @Test
-    public void shouldReturnErrorSelectWhenOrderIsNull() {
+    void shouldReturnErrorSelectWhenOrderIsNull() {
         Assertions.assertThrows(NullPointerException.class, () -> template.select(Worker.class).orderBy(null));
     }
 

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -136,7 +136,7 @@ class DocumentCrudRepositoryProxyTest {
 
     @Test
     void shouldSaveUsingInsertWhenDataDoesNotExist() {
-        when(template.find(Person.class, Mockito.eq(10L)))
+        when(template.find(Person.class, 10L))
                 .thenReturn(Optional.empty());
 
 
@@ -153,7 +153,7 @@ class DocumentCrudRepositoryProxyTest {
 
     @Test
     void shouldSaveUsingUpdateWhenDataExists() {
-        when(template.find(Person.class, Mockito.eq(10L)))
+        when(template.find(Person.class, 10L))
                 .thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -288,7 +288,7 @@ class DocumentCrudRepositoryProxyTest {
     @Test
     void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
     }
 
     @Test
@@ -297,7 +297,7 @@ class DocumentCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
         personRepository.findAllById(Arrays.asList(10L, 11L, 12L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), any(Long.class));
     }
@@ -325,7 +325,7 @@ class DocumentCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
-        Mockito.verify(template).find(Person.class, Mockito.eq(10L));
+        Mockito.verify(template).find(Person.class, 10L);
 
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.empty());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -136,7 +136,7 @@ public class DocumentCrudRepositoryProxyTest {
 
     @Test
     public void shouldSaveUsingInsertWhenDataDoesNotExist() {
-        when(template.find(Mockito.eq(Person.class), Mockito.eq(10L)))
+        when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.empty());
 
 
@@ -153,7 +153,7 @@ public class DocumentCrudRepositoryProxyTest {
 
     @Test
     public void shouldSaveUsingUpdateWhenDataExists() {
-        when(template.find(Mockito.eq(Person.class), Mockito.eq(10L)))
+        when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -290,7 +290,7 @@ public class DocumentCrudRepositoryProxyTest {
     @Test
     public void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
@@ -299,7 +299,7 @@ public class DocumentCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
         personRepository.findAllById(Arrays.asList(10L, 11L, 12L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), any(Long.class));
     }
@@ -327,7 +327,7 @@ public class DocumentCrudRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
-        Mockito.verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        Mockito.verify(template).find(Person.class, Mockito.eq(10L));
 
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.empty());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentCrudRepositoryProxyTest.java
@@ -90,7 +90,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, DocumentWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, DocumentExtension.class})
-public class DocumentCrudRepositoryProxyTest {
+class DocumentCrudRepositoryProxyTest {
 
     private JNoSQLDocumentTemplate template;
 
@@ -135,7 +135,7 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.empty());
 
@@ -152,7 +152,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
         when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -167,9 +167,8 @@ public class DocumentCrudRepositoryProxyTest {
         assertEquals(person, value);
     }
 
-
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
 
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
@@ -188,9 +187,8 @@ public class DocumentCrudRepositoryProxyTest {
         assertEquals(person, personCapture);
     }
 
-
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         when(template.singleResult(Mockito.any(DocumentQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -215,7 +213,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAge() {
+    void shouldFindByNameANDAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -230,7 +228,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeANDName() {
+    void shouldFindByAgeANDName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -245,7 +243,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByName() {
+    void shouldFindByNameANDAgeOrderByName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -260,7 +258,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByAge() {
+    void shouldFindByNameANDAgeOrderByAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -275,7 +273,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         ArgumentCaptor<DocumentDeleteQuery> captor = ArgumentCaptor.forClass(DocumentDeleteQuery.class);
         personRepository.deleteByName("Ada");
         verify(template).delete(captor.capture());
@@ -288,13 +286,13 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         personRepository.findById(10L);
         verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -305,14 +303,14 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         personRepository.deleteById(10L);
         verify(template).delete(Person.class, 10L);
 
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(Person.class, 10L);
 
@@ -322,7 +320,7 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -336,7 +334,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -351,7 +349,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         ArgumentCaptor<Class<?>> captor = ArgumentCaptor.forClass(Class.class);
         verify(template).deleteAll(captor.capture());
@@ -361,17 +359,17 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterEqualThan() {
+    void shouldFindByNameAndAgeGreaterEqualThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -401,7 +399,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByGreaterThan() {
+    void shouldFindByGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -420,7 +418,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessThanEqual() {
+    void shouldFindByAgeLessThanEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -439,7 +437,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessEqual() {
+    void shouldFindByAgeLessEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -459,7 +457,7 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByAgeBetween() {
+    void shouldFindByAgeBetween() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -482,7 +480,7 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameLike() {
+    void shouldFindByNameLike() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -500,7 +498,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -520,7 +518,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -540,7 +538,7 @@ public class DocumentCrudRepositoryProxyTest {
 
 
     @Test
-    public void shouldConvertFieldToTheType() {
+    void shouldConvertFieldToTheType() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -558,25 +556,25 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldGotOrderException() {
+    void shouldGotOrderException() {
         org.junit.jupiter.api.Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findBy());
     }
 
     @Test
-    public void shouldGotOrderException2() {
+    void shouldGotOrderException2() {
         org.junit.jupiter.api.Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findByException());
     }
 
     @Test
-    public void shouldExecuteJNoSQLQuery() {
+    void shouldExecuteJNoSQLQuery() {
         personRepository.findByQuery();
         verify(template).query("select * from Person");
     }
 
     @Test
-    public void shouldExecuteJNoSQLPrepare() {
+    void shouldExecuteJNoSQLPrepare() {
         PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString())).thenReturn(statement);
         personRepository.findByQuery("Ada");
@@ -584,7 +582,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_Currency() {
+    void shouldFindBySalary_Currency() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -603,7 +601,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyAndSalary_Value() {
+    void shouldFindBySalary_CurrencyAndSalary_Value() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
         when(template.select(any(DocumentQuery.class)))
@@ -624,7 +622,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
+    void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -645,7 +643,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNotEquals() {
+    void shouldFindByNameNotEquals() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -665,7 +663,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNot() {
+    void shouldFindByNameNot() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -685,7 +683,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeNotGreaterThan() {
+    void shouldFindByAgeNotGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -705,7 +703,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldConvertMapAddressRepository() {
+    void shouldConvertMapAddressRepository() {
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
         addressRepository.findByZipCodeZip("123456");
@@ -726,7 +724,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldConvertMapAddressRepositoryOrder() {
+    void shouldConvertMapAddressRepositoryOrder() {
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
         addressRepository.findByZipCodeZipOrderByZipCodeZip("123456");
@@ -750,7 +748,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExecuteDefaultMethod() {
+    void shouldExecuteDefaultMethod() {
         personRepository.partcionate("name");
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
@@ -760,7 +758,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseQueriesFromOtherInterface() {
+    void shouldUseQueriesFromOtherInterface() {
         personRepository.findByNameLessThan("name");
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
@@ -773,7 +771,7 @@ public class DocumentCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseDefaultMethodFromOtherInterface() {
+    void shouldUseDefaultMethodFromOtherInterface() {
         personRepository.ada();
 
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
@@ -122,7 +122,7 @@ class DocumentRepositoryProxyTest {
 
     @Test
     void shouldSaveUsingInsertWhenDataDoesNotExist() {
-        when(template.find(Person.class, Mockito.eq(10L)))
+        when(template.find(Person.class, 10L))
                 .thenReturn(Optional.empty());
 
 
@@ -139,7 +139,7 @@ class DocumentRepositoryProxyTest {
 
     @Test
     void shouldSaveUsingUpdateWhenDataExists() {
-        when(template.find(Person.class, Mockito.eq(10L)))
+        when(template.find(Person.class, 10L))
                 .thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -276,7 +276,7 @@ class DocumentRepositoryProxyTest {
     @Test
     void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
     }
 
     @Test
@@ -285,7 +285,7 @@ class DocumentRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Person.class, Mockito.eq(10L));
+        verify(template).find(Person.class, 10L);
         personRepository.findAllById(Arrays.asList(10L, 11L, 12L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), any(Long.class));
     }
@@ -313,7 +313,7 @@ class DocumentRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
-        Mockito.verify(template).find(Person.class, Mockito.eq(10L));
+        Mockito.verify(template).find(Person.class, 10L);
 
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.empty());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
@@ -122,7 +122,7 @@ public class DocumentRepositoryProxyTest {
 
     @Test
     public void shouldSaveUsingInsertWhenDataDoesNotExist() {
-        when(template.find(Mockito.eq(Person.class), Mockito.eq(10L)))
+        when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.empty());
 
 
@@ -139,7 +139,7 @@ public class DocumentRepositoryProxyTest {
 
     @Test
     public void shouldSaveUsingUpdateWhenDataExists() {
-        when(template.find(Mockito.eq(Person.class), Mockito.eq(10L)))
+        when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -276,7 +276,7 @@ public class DocumentRepositoryProxyTest {
     @Test
     public void shouldFindById() {
         personRepository.findById(10L);
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
@@ -285,7 +285,7 @@ public class DocumentRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         personRepository.findAllById(singletonList(10L)).toList();
-        verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        verify(template).find(Person.class, Mockito.eq(10L));
         personRepository.findAllById(Arrays.asList(10L, 11L, 12L)).toList();
         verify(template, times(4)).find(Mockito.eq(Person.class), any(Long.class));
     }
@@ -313,7 +313,7 @@ public class DocumentRepositoryProxyTest {
                 .thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
-        Mockito.verify(template).find(Mockito.eq(Person.class), Mockito.eq(10L));
+        Mockito.verify(template).find(Person.class, Mockito.eq(10L));
 
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.empty());

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
@@ -84,7 +84,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, DocumentWorkflow.class})
 @AddPackages(MockProducer.class)
 @AddExtensions({EntityMetadataExtension.class, DocumentExtension.class})
-public class DocumentRepositoryProxyTest {
+class DocumentRepositoryProxyTest {
 
     private JNoSQLDocumentTemplate template;
 
@@ -121,7 +121,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.empty());
 
@@ -138,7 +138,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
         when(template.find(Person.class, Mockito.eq(10L)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -155,7 +155,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
 
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
@@ -176,7 +176,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         when(template.singleResult(Mockito.any(DocumentQuery.class))).thenReturn(Optional
                 .of(Person.builder().build()));
@@ -201,7 +201,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAge() {
+    void shouldFindByNameANDAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -216,7 +216,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeANDName() {
+    void shouldFindByAgeANDName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -231,7 +231,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByName() {
+    void shouldFindByNameANDAgeOrderByName() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -246,7 +246,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameANDAgeOrderByAge() {
+    void shouldFindByNameANDAgeOrderByAge() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -261,7 +261,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         ArgumentCaptor<DocumentDeleteQuery> captor = ArgumentCaptor.forClass(DocumentDeleteQuery.class);
         personRepository.deleteByName("Ada");
         verify(template).delete(captor.capture());
@@ -274,13 +274,13 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         personRepository.findById(10L);
         verify(template).find(Person.class, Mockito.eq(10L));
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -291,14 +291,14 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         personRepository.deleteById(10L);
         verify(template).delete(Person.class, 10L);
 
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(Person.class, 10L);
 
@@ -308,7 +308,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(Mockito.eq(Person.class), Mockito.any(Long.class)))
                 .thenReturn(Optional.of(Person.builder().build()));
 
@@ -322,7 +322,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -337,7 +337,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         ArgumentCaptor<Class<?>> captor = ArgumentCaptor.forClass(Class.class);
         verify(template).deleteAll(captor.capture());
@@ -347,23 +347,23 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertNotNull(personRepository.hashCode());
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldReturnEquals() {
+    void shouldReturnEquals() {
         assertNotNull(personRepository.equals(personRepository));
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterEqualThan() {
+    void shouldFindByNameAndAgeGreaterEqualThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -393,7 +393,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByGreaterThan() {
+    void shouldFindByGreaterThan() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -412,7 +412,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessThanEqual() {
+    void shouldFindByAgeLessThanEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -431,7 +431,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeLessEqual() {
+    void shouldFindByAgeLessEqual() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -451,7 +451,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByAgeBetween() {
+    void shouldFindByAgeBetween() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -474,7 +474,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldFindByNameLike() {
+    void shouldFindByNameLike() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -492,7 +492,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -512,7 +512,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -532,7 +532,7 @@ public class DocumentRepositoryProxyTest {
 
 
     @Test
-    public void shouldConvertFieldToTheType() {
+    void shouldConvertFieldToTheType() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -550,7 +550,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveTrue() {
+    void shouldFindByActiveTrue() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -569,7 +569,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveFalse() {
+    void shouldFindByActiveFalse() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -587,13 +587,13 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExecuteJNoSQLQuery() {
+    void shouldExecuteJNoSQLQuery() {
         personRepository.findByQuery();
         verify(template).query("select * from Person");
     }
 
     @Test
-    public void shouldExecuteJNoSQLPrepare() {
+    void shouldExecuteJNoSQLPrepare() {
         PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString())).thenReturn(statement);
         personRepository.findByQuery("Ada");
@@ -601,7 +601,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_Currency() {
+    void shouldFindBySalary_Currency() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -620,7 +620,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyAndSalary_Value() {
+    void shouldFindBySalary_CurrencyAndSalary_Value() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
         when(template.select(any(DocumentQuery.class)))
@@ -641,7 +641,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
+    void shouldFindBySalary_CurrencyOrderByCurrency_Name() {
         Person ada = Person.builder()
                 .withAge(20).withName("Ada").build();
 
@@ -662,7 +662,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldCountByName() {
+    void shouldCountByName() {
         when(template.count(any(DocumentQuery.class)))
                 .thenReturn(10L);
 
@@ -679,7 +679,7 @@ public class DocumentRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExistsByName() {
+    void shouldExistsByName() {
         when(template.exists(any(DocumentQuery.class)))
                 .thenReturn(true);
 


### PR DESCRIPTION
My change suggestions are about `refact`:

1. `Mockito.eq` is not needed in that's cases.
2. `public` keyword is not needed.
3. `sort.isAscending() == true` is not needed.

Thank you.