### PR TITLE
(refact): swap expected vs actual

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryConditionTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryConditionTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DefaultQueryConditionTest {
-
     private QueryValue<Boolean> queryValue;
 
     @BeforeEach
@@ -31,8 +30,8 @@ class DefaultQueryConditionTest {
     public void shouldCreateCondition() {
         QueryCondition condition = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         assertThat(condition).isNotNull();
-        assertEquals(condition.condition(), Condition.EQUALS);
-        assertEquals(condition.name(), "active");
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals("active", condition.name());
         assertEquals(condition.value(), queryValue);
     }
 
@@ -49,5 +48,4 @@ class DefaultQueryConditionTest {
         QueryCondition conditionB = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         assertEquals(condition.hashCode(),conditionB.hashCode());
     }
-
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryConditionTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryConditionTest.java
@@ -27,7 +27,7 @@ class DefaultQueryConditionTest {
     }
 
     @Test
-    public void shouldCreateCondition() {
+    void shouldCreateCondition() {
         QueryCondition condition = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         assertThat(condition).isNotNull();
         assertEquals(Condition.EQUALS, condition.condition());
@@ -36,14 +36,14 @@ class DefaultQueryConditionTest {
     }
 
     @Test
-    public void shouldEquals() {
+    void shouldEquals() {
         QueryCondition condition = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         QueryCondition conditionB = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         assertEquals(condition,conditionB);
     }
 
     @Test
-    public void shouldHashCode() {
+    void shouldHashCode() {
         QueryCondition condition = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         QueryCondition conditionB = new DefaultQueryCondition("active", Condition.EQUALS, queryValue);
         assertEquals(condition.hashCode(),conditionB.hashCode());

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
@@ -34,7 +34,7 @@ class WhereTest {
     }
 
     @Test
-    public void shouldCreateInstance() {
+    void shouldCreateInstance() {
         Where where = Where.of(condition);
         Assertions.assertThat(where).isNotNull()
                 .extracting(Where::condition)
@@ -42,7 +42,7 @@ class WhereTest {
     }
 
     @Test
-    public void shouldEquals() {
+    void shouldEquals() {
         Where where = Where.of(condition);
         assertEquals(where, where, "should be equals to yourself");
         assertEquals(where, Where.of(condition));
@@ -52,13 +52,13 @@ class WhereTest {
 
 
     @Test
-    public void shouldHashCode() {
+    void shouldHashCode() {
         Where where = Where.of(condition);
         assertEquals(where.hashCode(), Where.of(condition).hashCode());
     }
 
     @Test
-    public void shouldToString() {
+    void shouldToString() {
         Where where = Where.of(condition);
         String actual = where.toString();
         assertNotNull(actual);

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/WhereTest.java
@@ -17,10 +17,12 @@ import org.eclipse.jnosql.communication.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WhereTest {
-
     private QueryCondition condition;
 
     private QueryValue<Boolean> queryValue;
@@ -45,7 +47,7 @@ class WhereTest {
         assertEquals(where, where, "should be equals to yourself");
         assertEquals(where, Where.of(condition));
         assertNotEquals(where, new Object(), "should be not equal to an instance of any other type");
-        assertNotEquals(where, null, "should be not equal to null reference");
+        assertNotEquals(null, where, "should be not equal to null reference");
     }
 
 
@@ -62,5 +64,4 @@ class WhereTest {
         assertNotNull(actual);
         assertTrue(actual.startsWith("where "));
     }
-
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/MethodConditionTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/MethodConditionTest.java
@@ -31,7 +31,7 @@ class MethodConditionTest {
     }
 
     @Test
-    public void shouldCreateCondition() {
+    void shouldCreateCondition() {
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS, queryValue);
         assertThat(condition).isNotNull();
         assertEquals(Condition.EQUALS, condition.condition());
@@ -40,21 +40,21 @@ class MethodConditionTest {
     }
 
     @Test
-    public void shouldEquals() {
+    void shouldEquals() {
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS, queryValue);
         QueryCondition conditionB = new MethodCondition("active", Condition.EQUALS, queryValue);
         assertEquals(condition,conditionB);
     }
 
     @Test
-    public void shouldHashCode() {
+    void shouldHashCode() {
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS, queryValue);
         QueryCondition conditionB = new MethodCondition("active", Condition.EQUALS, queryValue);
         assertEquals(condition.hashCode(),conditionB.hashCode());
     }
 
     @Test
-    public void shouldCreateWithQueryParam(){
+    void shouldCreateWithQueryParam(){
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS);
         assertThat(condition).isNotNull();
         assertEquals(Condition.EQUALS, condition.condition());

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/MethodConditionTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/MethodConditionTest.java
@@ -20,10 +20,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MethodConditionTest {
-
     private QueryValue<Boolean> queryValue;
 
     @BeforeEach
@@ -35,8 +34,8 @@ class MethodConditionTest {
     public void shouldCreateCondition() {
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS, queryValue);
         assertThat(condition).isNotNull();
-        assertEquals(condition.condition(), Condition.EQUALS);
-        assertEquals(condition.name(), "active");
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals("active", condition.name());
         assertEquals(condition.value(), queryValue);
     }
 
@@ -58,8 +57,8 @@ class MethodConditionTest {
     public void shouldCreateWithQueryParam(){
         QueryCondition condition = new MethodCondition("active", Condition.EQUALS);
         assertThat(condition).isNotNull();
-        assertEquals(condition.condition(), Condition.EQUALS);
-        assertEquals(condition.name(), "active");
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals("active", condition.name());
         Assertions.assertThat(condition.value()).isInstanceOf(MethodParamQueryValue.class);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphCrudRepositoryProxyTest.java
@@ -70,13 +70,10 @@ import static org.mockito.Mockito.when;
 @AddPackages(BookRepository.class)
 @AddExtensions({EntityMetadataExtension.class, GraphExtension.class})
 public class GraphCrudRepositoryProxyTest {
-
-
     private GraphTemplate template;
 
     @Inject
     private EntitiesMetadata entities;
-
 
     @Inject
     private Graph graph;
@@ -267,7 +264,7 @@ public class GraphCrudRepositoryProxyTest {
         personRepository.deleteById(10L);
         verify(template).delete(captor.capture());
 
-        assertEquals(captor.getValue(), 10L);
+        assertEquals(10L, captor.getValue());
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphCrudRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphCrudRepositoryProxyTest.java
@@ -69,7 +69,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, Transactional.class})
 @AddPackages(BookRepository.class)
 @AddExtensions({EntityMetadataExtension.class, GraphExtension.class})
-public class GraphCrudRepositoryProxyTest {
+class GraphCrudRepositoryProxyTest {
     private GraphTemplate template;
 
     @Inject
@@ -123,9 +123,8 @@ public class GraphCrudRepositoryProxyTest {
 
     }
 
-
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Mockito.any(Long.class))).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -140,7 +139,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
         when(template.find(Mockito.any(Long.class))).thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -154,9 +153,8 @@ public class GraphCrudRepositoryProxyTest {
         assertEquals(person, value);
     }
 
-
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -171,9 +169,8 @@ public class GraphCrudRepositoryProxyTest {
         assertEquals(person, personCapture);
     }
 
-
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
 
@@ -184,7 +181,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameAndAge() {
+    void shouldFindByNameAndAge() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -195,7 +192,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeAndName() {
+    void shouldFindByAgeAndName() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -206,7 +203,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAge() {
+    void shouldFindByAge() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
 
@@ -216,7 +213,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         Vertex vertex = graph.addVertex(T.label, "Person", "name", "Ada", "age", 20);
 
         personRepository.deleteByName("Ada");
@@ -225,7 +222,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterThanEqual() {
+    void shouldFindByNameAndAgeGreaterThanEqual() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -236,7 +233,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         personRepository.findById(10L);
         verify(template).find(captor.capture());
@@ -247,7 +244,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
 
         when(template.find(any(Object.class))).thenReturn(Optional.empty());
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
@@ -259,7 +256,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         personRepository.deleteById(10L);
         verify(template).delete(captor.capture());
@@ -268,7 +265,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(10L);
 
@@ -276,9 +273,8 @@ public class GraphCrudRepositoryProxyTest {
         verify(template, times(4)).delete(any(Long.class));
     }
 
-
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(any(Long.class))).thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
@@ -290,37 +286,36 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         List<Person> people = personRepository.findAll().toList();
         verify(template).findAll(Person.class);
     }
 
-
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         verify(template).deleteAll(Person.class);
     }
 
     @Test
-    public void shouldReturnEmptyAtFindAll() {
+    void shouldReturnEmptyAtFindAll() {
         List<Person> people = personRepository.findAll().toList();
         assertTrue(people.isEmpty());
     }
 
 
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldExecuteQuery() {
+    void shouldExecuteQuery() {
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         personRepository.findByQuery();
@@ -334,7 +329,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExecuteQuery2() {
+    void shouldExecuteQuery2() {
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString()))
@@ -349,7 +344,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -361,7 +356,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -376,7 +371,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNot() {
+    void shouldFindByNameNot() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -394,7 +389,7 @@ public class GraphCrudRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameNotEquals() {
+    void shouldFindByNameNotEquals() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -76,13 +76,10 @@ import static org.mockito.Mockito.when;
 @AddPackages(BookRepository.class)
 @AddExtensions({EntityMetadataExtension.class, GraphExtension.class})
 public class GraphRepositoryProxyTest {
-
-
     private GraphTemplate template;
 
     @Inject
     private EntitiesMetadata entities;
-
 
     @Inject
     private Graph graph;
@@ -273,7 +270,7 @@ public class GraphRepositoryProxyTest {
         personRepository.deleteById(10L);
         verify(template).delete(captor.capture());
 
-        assertEquals(captor.getValue(), 10L);
+        assertEquals(10L, captor.getValue());
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.when;
 @AddPackages(value = {Convert.class, Transactional.class})
 @AddPackages(BookRepository.class)
 @AddExtensions({EntityMetadataExtension.class, GraphExtension.class})
-public class GraphRepositoryProxyTest {
+class GraphRepositoryProxyTest {
     private GraphTemplate template;
 
     @Inject
@@ -95,7 +95,7 @@ public class GraphRepositoryProxyTest {
     private VendorRepository vendorRepository;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
 
         graph.traversal().V().toList().forEach(Vertex::remove);
         graph.traversal().E().toList().forEach(Edge::remove);
@@ -123,15 +123,14 @@ public class GraphRepositoryProxyTest {
     }
 
     @AfterEach
-    public void after() {
+    void after() {
         graph.traversal().V().toList().forEach(Vertex::remove);
         graph.traversal().E().toList().forEach(Edge::remove);
 
     }
 
-
     @Test
-    public void shouldSaveUsingInsertWhenDataDoesNotExist() {
+    void shouldSaveUsingInsertWhenDataDoesNotExist() {
         when(template.find(Mockito.any(Long.class))).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -146,7 +145,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldSaveUsingUpdateWhenDataExists() {
+    void shouldSaveUsingUpdateWhenDataExists() {
         when(template.find(Mockito.any(Long.class))).thenReturn(Optional.of(Person.builder().build()));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -160,9 +159,8 @@ public class GraphRepositoryProxyTest {
         assertEquals(person, value);
     }
 
-
     @Test
-    public void shouldSaveIterable() {
+    void shouldSaveIterable() {
         when(personRepository.findById(10L)).thenReturn(Optional.empty());
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
@@ -177,9 +175,8 @@ public class GraphRepositoryProxyTest {
         assertEquals(person, personCapture);
     }
 
-
     @Test
-    public void shouldFindByNameInstance() {
+    void shouldFindByNameInstance() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
 
@@ -190,7 +187,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameAndAge() {
+    void shouldFindByNameAndAge() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -201,7 +198,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeAndName() {
+    void shouldFindByAgeAndName() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -212,7 +209,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAge() {
+    void shouldFindByAge() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
 
@@ -222,7 +219,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByName() {
+    void shouldDeleteByName() {
         Vertex vertex = graph.addVertex(T.label, "Person", "name", "Ada", "age", 20);
 
         personRepository.deleteByName("Ada");
@@ -231,7 +228,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameAndAgeGreaterThanEqual() {
+    void shouldFindByNameAndAgeGreaterThanEqual() {
 
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
@@ -242,7 +239,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindById() {
+    void shouldFindById() {
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         personRepository.findById(10L);
         verify(template).find(captor.capture());
@@ -253,7 +250,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIds() {
+    void shouldFindByIds() {
 
         when(template.find(any(Object.class))).thenReturn(Optional.empty());
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
@@ -265,7 +262,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteById() {
+    void shouldDeleteById() {
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         personRepository.deleteById(10L);
         verify(template).delete(captor.capture());
@@ -274,7 +271,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldDeleteByIds() {
+    void shouldDeleteByIds() {
         personRepository.deleteAllById(singletonList(10L));
         verify(template).delete(10L);
 
@@ -282,9 +279,8 @@ public class GraphRepositoryProxyTest {
         verify(template, times(4)).delete(any(Long.class));
     }
 
-
     @Test
-    public void shouldContainsById() {
+    void shouldContainsById() {
         when(template.find(any(Long.class))).thenReturn(Optional.of(Person.builder().build()));
 
         assertTrue(personRepository.existsById(10L));
@@ -296,38 +292,36 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    void shouldFindAll() {
         List<Person> people = personRepository.findAll().toList();
         verify(template).findAll(Person.class);
     }
 
-
     @Test
-    public void shouldDeleteAll() {
+    void shouldDeleteAll() {
         personRepository.deleteAll();
         verify(template).deleteAll(Person.class);
     }
 
     @Test
-    public void shouldReturnEmptyAtFindAll() {
+    void shouldReturnEmptyAtFindAll() {
         List<Person> people = personRepository.findAll().toList();
         assertTrue(people.isEmpty());
     }
 
-
     @Test
-    public void shouldReturnToString() {
+    void shouldReturnToString() {
         assertNotNull(personRepository.toString());
     }
 
     @Test
-    public void shouldReturnHasCode() {
+    void shouldReturnHasCode() {
         assertNotNull(personRepository.hashCode());
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 
     @Test
-    public void shouldExecuteQuery() {
+    void shouldExecuteQuery() {
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         graph.addVertex(T.label, "Person", "name", "name", "age", 20);
         personRepository.findByQuery();
@@ -341,7 +335,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveTrue() {
+    void shouldFindByActiveTrue() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", true);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", true);
@@ -353,7 +347,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByActiveFalse() {
+    void shouldFindByActiveFalse() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", true);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", true);
@@ -365,7 +359,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByNameEquals() {
+    void shouldFindByNameEquals() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", false);
@@ -377,7 +371,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByAgeNotGreaterThan() {
+    void shouldFindByAgeNotGreaterThan() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", false);
@@ -389,7 +383,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldCountByActiveFalse() {
+    void shouldCountByActiveFalse() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", true);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", true);
@@ -400,7 +394,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExistsByActiveFalse() {
+    void shouldExistsByActiveFalse() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", true);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", true);
@@ -411,7 +405,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExistsByActiveFalse2() {
+    void shouldExistsByActiveFalse2() {
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false);
         graph.addVertex(T.label, "Person", "name", "Ada", "age", 30, "active", false);
@@ -422,18 +416,18 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldGotOrderException() {
+    void shouldGotOrderException() {
         Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findBy());
     }
 
     @Test
-    public void shouldGotOrderException2() {
+    void shouldGotOrderException2() {
         Assertions.assertThrows(MappingException.class, () ->
                 personRepository.findByException());
     }
     @Test
-    public void shouldExecuteQuery2() {
+    void shouldExecuteQuery2() {
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         when(template.prepare(Mockito.anyString()))
@@ -448,7 +442,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByStringWhenFieldIsSet() {
+    void shouldFindByStringWhenFieldIsSet() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -460,7 +454,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldFindByIn() {
+    void shouldFindByIn() {
         Vendor vendor = new Vendor("vendor");
         vendor.setPrefixes(Collections.singleton("prefix"));
 
@@ -474,7 +468,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldExecuteDefaultMethod() {
+    void shouldExecuteDefaultMethod() {
 
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false);
@@ -493,7 +487,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseQueriesFromOtherInterface() {
+    void shouldUseQueriesFromOtherInterface() {
 
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false, "score", 2);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false, "score", 12);
@@ -506,7 +500,7 @@ public class GraphRepositoryProxyTest {
     }
 
     @Test
-    public void shouldUseDefaultMethodFromOtherInterface() {
+    void shouldUseDefaultMethodFromOtherInterface() {
 
         graph.addVertex(T.label, "Person", "name", "Otavio", "age", 30, "active", false, "score", 2);
         graph.addVertex(T.label, "Person", "name", "Poliana", "age", 20, "active", false, "score", 12);


### PR DESCRIPTION
My change suggestions are about `refact`:

1. In `assertEquals` the _first_ args must be the expected.
2. `public` keyword is not needed.
3. Some cases are two/three white lines in a row, I mean it's too much, so I removed them.

Thank you.