### PR TITLE
Update Entities Medatada for lazy loading

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 == Fixed
 
 - Added no-args constructor into the injectable beans
+- Fixes lazy loading metadata at the EntityMetadata
 
 == [1.0.0] - 2023-6-22
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
@@ -65,14 +65,14 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
     }
 
     EntityMetadata load(Class<?> type) {
-        EntityMetadata entityMetadata = classConverter.create(type);
-        if (entityMetadata.hasEntityName()) {
-            mappings.put(type.getName(), entityMetadata);
+        EntityMetadata metadata = classConverter.create(type);
+        if (metadata.hasEntityName()) {
+            mappings.put(type.getName(), metadata);
         }
-        this.findBySimpleName.put(type.getSimpleName(), entityMetadata);
-        this.findByClassName.put(type.getName(), entityMetadata);
-        this.classes.put(type, entityMetadata);
-        return entityMetadata;
+        this.findBySimpleName.put(type.getSimpleName(), metadata);
+        this.findByClassName.put(type.getName(), metadata);
+        this.classes.put(type, metadata);
+        return metadata;
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
@@ -64,24 +64,24 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
         });
     }
 
-    void load(Class<?> classEntity) {
-        EntityMetadata entityMetadata = classConverter.create(classEntity);
+    void load(Class<?> type) {
+        EntityMetadata entityMetadata = classConverter.create(type);
         if (entityMetadata.hasEntityName()) {
-            mappings.put(classEntity.getName(), entityMetadata);
+            mappings.put(type.getName(), entityMetadata);
         }
-        findBySimpleName.put(classEntity.getSimpleName(), entityMetadata);
-        findByClassName.put(classEntity.getName(), entityMetadata);
+        this.findBySimpleName.put(type.getSimpleName(), entityMetadata);
+        this.findByClassName.put(type.getName(), entityMetadata);
+        this.classes.put(type, entityMetadata);
     }
 
     @Override
-    public EntityMetadata get(Class<?> classEntity) {
-        EntityMetadata entityMetadata = classes.get(classEntity);
-        if (entityMetadata == null) {
-            entityMetadata = classConverter.create(classEntity);
-            classes.put(classEntity, entityMetadata);
-            return this.get(classEntity);
+    public EntityMetadata get(Class<?> type) {
+        EntityMetadata metadata = classes.get(type);
+        if (metadata == null) {
+           load(type);
+            return this.get(type);
         }
-        return entityMetadata;
+        return metadata;
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
@@ -64,7 +64,7 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
         });
     }
 
-    void load(Class<?> type) {
+    EntityMetadata load(Class<?> type) {
         EntityMetadata entityMetadata = classConverter.create(type);
         if (entityMetadata.hasEntityName()) {
             mappings.put(type.getName(), entityMetadata);
@@ -72,14 +72,14 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
         this.findBySimpleName.put(type.getSimpleName(), entityMetadata);
         this.findByClassName.put(type.getName(), entityMetadata);
         this.classes.put(type, entityMetadata);
+        return entityMetadata;
     }
 
     @Override
-    public EntityMetadata get(Class<?> type) {
-        EntityMetadata metadata = classes.get(type);
+    public EntityMetadata get(Class<?> entity) {
+        EntityMetadata metadata = classes.get(entity);
         if (metadata == null) {
-           load(type);
-            return this.get(type);
+           return load(entity);
         }
         return metadata;
     }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/EntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/EntitiesMetadata.java
@@ -28,11 +28,11 @@ public interface EntitiesMetadata {
      * Find a class in the cached way and return in a class,
      * if it's not found the class will be both, loaded and cached, when this method is called
      *
-     * @param classEntity the class of entity
+     * @param entity the class of entity
      * @return the {@link EntityMetadata}
      * @throws NullPointerException when class entity is null
      */
-    EntityMetadata get(Class<?> classEntity);
+    EntityMetadata get(Class<?> entity);
 
     /**
      * Find the {@link InheritanceMetadata} where the parameter is the parent parameter

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadataTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadataTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.mapping.reflection;
 
 import org.eclipse.jnosql.mapping.Convert;
 import org.eclipse.jnosql.mapping.VetedConverter;
+import org.eclipse.jnosql.mapping.test.entities.Movie;
 import org.eclipse.jnosql.mapping.test.entities.Person;
 import org.eclipse.jnosql.mapping.test.entities.Vendor;
 import org.eclipse.jnosql.mapping.test.entities.inheritance.EmailNotification;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.inject.Inject;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = Convert.class)
@@ -129,5 +132,13 @@ class DefaultEntitiesMetadataTest {
         Assertions.assertNotNull(group.get("Small"));
         Assertions.assertNotNull(group.get("Large"));
         Assertions.assertNotNull(group.get("Project"));
+    }
+
+    @Test
+    public void shouldLoadUsingGet(){
+        this.mappings.load(Movie.class);
+        EntityMetadata mapping = mappings.findByName("Movie");
+        assertThat(mapping).isNotNull();
+        Assertions.assertEquals(Movie.class, mapping.type());
     }
 }


### PR DESCRIPTION
# Changes

- Update the EntitiesMetadata, making lazy loading when the entity is not loaded from the extension

Fixes this issue: https://github.com/quarkiverse/quarkus-jnosql/issues/25