### PR TITLE
refact: assertNotNull with primitive

### DIFF
--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -353,8 +353,7 @@ class ColumnRepositoryProxyTest {
     }
 
     @Test
-    void shouldReturnHasCode() {
-        assertNotNull(personRepository.hashCode());
+    void shouldReturnSameHashCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/query/ColumnRepositoryProxyTest.java
@@ -358,8 +358,8 @@ class ColumnRepositoryProxyTest {
     }
 
     @Test
-    void shouldReturnEquals() {
-        assertNotNull(personRepository.equals(personRepository));
+    void shouldReturnNotNull() {
+        assertNotNull(personRepository);
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
@@ -357,8 +357,8 @@ class DocumentRepositoryProxyTest {
     }
 
     @Test
-    void shouldReturnEquals() {
-        assertNotNull(personRepository.equals(personRepository));
+    void shouldReturnNotNull() {
+        assertNotNull(personRepository);
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/query/DocumentRepositoryProxyTest.java
@@ -352,8 +352,7 @@ class DocumentRepositoryProxyTest {
     }
 
     @Test
-    void shouldReturnHasCode() {
-        assertNotNull(personRepository.hashCode());
+    void shouldReturnSameHashCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/query/GraphRepositoryProxyTest.java
@@ -60,7 +60,6 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.jnosql.communication.Condition.LESSER_THAN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -315,8 +314,7 @@ class GraphRepositoryProxyTest {
     }
 
     @Test
-    void shouldReturnHasCode() {
-        assertNotNull(personRepository.hashCode());
+    void shouldReturnSameHashCode() {
         assertEquals(personRepository.hashCode(), personRepository.hashCode());
     }
 


### PR DESCRIPTION
My change suggestions are about `refact`:

1. Removing the `AssertNotNull` with hashCode(), because hashCode() is primitive.
2. It was missing a **H** in shoudReturnHas**h**Code:
    1. I had the idea _to suggest_ `shouldReturnSameHashCode`
3. `personRepository.equals(personRepository)`, returns false, i had the idea _to suggest_:
    1. Rename de method to: `shouldReturnNotNull`
    2. Use only one argument
4. Removed an import that was lost.

Thank you.