### PR TITLE
Fixes ParameterMedataData to not thrown NullPointException when it's built with a Parameter without @Column or @Id annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ test-output/
 # Annotation processor metadata
 .apt_generated/
 .apt_generated_tests/
+
+# Quarkus Plugin dir
+
+.quarkus/

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 - Added no-args constructor into the injectable beans
 - Fixes lazy loading metadata at the EntityMetadata
+- Fixes ParameterMedataData to not thrown NullPointException when it's built with a Parameter without @Column or @Id annotations
 
 == [1.0.0] - 2023-6-22
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/ParameterMetaDataBuilder.java
@@ -37,7 +37,8 @@ class ParameterMetaDataBuilder {
         Class<?> type = parameter.getType();
         String name = Optional.ofNullable(id)
                 .map(Id::value)
-                .orElseGet(() -> column.value());
+                .or(() -> Optional.ofNullable(column).map(Column::value))
+                .orElse(null);
         if ((Objects.isNull(name) || name.isBlank())
                 && parameter.getDeclaringExecutable().getDeclaringClass().isRecord()) {
             name = parameter.getName();

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassScannerTest.java
@@ -38,7 +38,7 @@ class ClassScannerTest {
     public void shouldReturnEntities() {
         Set<Class<?>> entities = classScanner.entities();
         Assertions.assertNotNull(entities);
-        assertThat(entities).hasSize(25)
+        assertThat(entities).hasSize(26)
                 .contains(Person.class);
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
@@ -26,6 +26,7 @@ import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.Optional;
 
@@ -58,6 +59,30 @@ public class ReflectionsTest {
             softly.assertThat(reflections.getEntityName(Tablet.class))
                     .as("getting entity name from annotated record class with @Entity with defined name")
                     .isEqualTo("tablet");
+        });
+    }
+
+    @Test
+    public void shouldReturnsConstructor() {
+        assertSoftly(softly -> {
+
+            Constructor<Person> personConstructor = reflections.getConstructor(Person.class);
+            softly.assertThat(personConstructor)
+                    .as("getting an non-args constructor from annotated class " +
+                            "with @Entity")
+                    .isNotNull();
+
+            Constructor<Smartphone> smartphoneConstructor = reflections.getConstructor(Smartphone.class);
+            softly.assertThat(smartphoneConstructor)
+                    .as("getting constructor from annotated entity record class " +
+                            "with @Entity with all field annotated or @Id or @Column")
+                    .isNotNull();
+
+            Constructor<Tablet> tableConstructor = reflections.getConstructor(Tablet.class);
+            softly.assertThat(tableConstructor)
+                    .as("getting constructor from annotated entity record class " +
+                            "with @Entity with field not annotated with @Column")
+                    .isNotNull();
         });
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
@@ -14,35 +14,24 @@
  */
 package org.eclipse.jnosql.mapping.reflection;
 
+import jakarta.inject.Inject;
 import org.eclipse.jnosql.mapping.Convert;
 import org.eclipse.jnosql.mapping.VetedConverter;
-import org.eclipse.jnosql.mapping.test.entities.Actor;
-import org.eclipse.jnosql.mapping.test.entities.Download;
-import org.eclipse.jnosql.mapping.test.entities.Movie;
-import org.eclipse.jnosql.mapping.test.entities.Person;
-import org.eclipse.jnosql.mapping.test.entities.Vendor;
-import org.eclipse.jnosql.mapping.test.entities.Worker;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.EmailNotification;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.LargeProject;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.Notification;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.Project;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.SmallProject;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.SmsNotification;
-import org.eclipse.jnosql.mapping.test.entities.inheritance.SocialMediaNotification;
+import org.eclipse.jnosql.mapping.test.entities.*;
+import org.eclipse.jnosql.mapping.test.entities.constructor.Smartphone;
+import org.eclipse.jnosql.mapping.test.entities.constructor.Tablet;
+import org.eclipse.jnosql.mapping.test.entities.inheritance.*;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
 
-import jakarta.inject.Inject;
 import java.lang.reflect.Field;
 import java.util.Optional;
 
-
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.mapping.DiscriminatorColumn.DEFAULT_DISCRIMINATOR_COLUMN;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @EnableAutoWeld
@@ -57,8 +46,20 @@ public class ReflectionsTest {
 
     @Test
     public void shouldReturnsEntityName() {
-        assertEquals("Person", reflections.getEntityName(Person.class));
-        assertEquals("movie", reflections.getEntityName(Movie.class));
+        assertSoftly(softly -> {
+            softly.assertThat(reflections.getEntityName(Person.class))
+                    .as("getting entity name from annotated class with @Entity without name")
+                    .isEqualTo("Person");
+            softly.assertThat(reflections.getEntityName(Movie.class))
+                    .as("getting entity name from annotated class with @Entity with defined name")
+                    .isEqualTo("movie");
+            softly.assertThat(reflections.getEntityName(Smartphone.class))
+                    .as("getting entity name from annotated record class with @Entity without name")
+                    .isEqualTo("Smartphone");
+            softly.assertThat(reflections.getEntityName(Tablet.class))
+                    .as("getting entity name from annotated record class with @Entity with defined name")
+                    .isEqualTo("tablet");
+        });
     }
 
     @Test
@@ -80,7 +81,7 @@ public class ReflectionsTest {
     }
 
     @Test
-    public void shouldGetEntityNameWhenThereIsNoAnnotation(){
+    public void shouldGetEntityNameWhenThereIsNoAnnotation() {
         String entityName = reflections.getEntityName(Person.class);
         assertEquals(Person.class.getSimpleName(), entityName);
     }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionsTest.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @AddExtensions(EntityMetadataExtension.class)
 public class ReflectionsTest {
 
-
     @Inject
     private Reflections reflections;
 
@@ -64,10 +63,20 @@ public class ReflectionsTest {
 
     @Test
     public void shouldListFields() {
-
-        assertEquals(4, reflections.getFields(Person.class).size());
-        assertEquals(6, reflections.getFields(Actor.class).size());
-
+        assertSoftly(softly -> {
+            softly.assertThat(reflections.getFields(Person.class))
+                    .as("list fields from a class with field not annotated with @Column")
+                    .hasSize(4);
+            softly.assertThat(reflections.getFields(Actor.class))
+                    .as("list fields from a class that extends a class with field not annotated with @Column")
+                    .hasSize(6);
+            softly.assertThat(reflections.getFields(Smartphone.class))
+                    .as("list fields from a record class with all fields annotated with @Id or @Column")
+                    .hasSize(2);
+            softly.assertThat(reflections.getFields(Tablet.class))
+                    .as("list fields from a record class with field not annotated with @Id or @Column")
+                    .hasSize(2);
+        });
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Tablet.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Tablet.java
@@ -20,5 +20,5 @@ import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
 
 @Entity("tablet")
-public record Tablet(@Id String id, @Column String model, @Column String owner) {
+public record Tablet(@Id String id, String model, @Column String owner) {
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Tablet.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/test/entities/constructor/Tablet.java
@@ -1,0 +1,24 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License v1.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.mapping.test.entities.constructor;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+@Entity("tablet")
+public record Tablet(@Id String id, @Column String model, @Column String owner) {
+}


### PR DESCRIPTION
### Changes
- Fixes ParameterMedataData to not throw NullPointException when it's built with a Parameter without `@Column` or `@Id` annotations;
- Tests enhancement for Java Records integration;