### PR TITLE
Fixes issue #407: Fixes Reflections.getConstructor() method logic to detect constructors with parameters annotated with @Id or @Column

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Added no-args constructor into the injectable beans
 - Fixes lazy loading metadata at the EntityMetadata
 - Fixes ParameterMedataData to not thrown NullPointException when it's built with a Parameter without @Column or @Id annotations
+- Fixes Reflections.getConstructor() method logic to detect constructors with parameters annotated with @Id or @Column
 
 == [1.0.0] - 2023-6-22
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/Reflections.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/reflection/Reflections.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -29,7 +30,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;


### PR DESCRIPTION
Fixes: https://github.com/eclipse/jnosql/issues/407

## Changes

- Fixes Reflections.getConstructor() method logic to detect constructors with parameters annotated with @Id or @Column
