### PR TITLE
refact: using especific methods in assertj

### DIFF
--- a/jnosql-communication/jnosql-communication-column/src/test/java/org/eclipse/jnosql/communication/column/ColumnDeleteQueryParamsTest.java
+++ b/jnosql-communication/jnosql-communication-column/src/test/java/org/eclipse/jnosql/communication/column/ColumnDeleteQueryParamsTest.java
@@ -102,7 +102,7 @@ class ColumnDeleteQueryParamsTest {
         var fistInstance = newInstance(firstQuery, firstParams);
         var secondInstance = newInstance(firstQuery, firstParams);
 
-        assertThat(fistInstance.hashCode()).isEqualTo(secondInstance.hashCode());
+        assertThat(fistInstance).hasSameHashCodeAs(secondInstance);
 
         ColumnDeleteQuery secondQuery = newDummyColumnDeleteQuery();
         Params secondParams = newDummyParams();

--- a/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/ParamsTest.java
+++ b/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/ParamsTest.java
@@ -171,7 +171,7 @@ class ParamsTest {
             Scenario scenario = newScenario();
             Params params = scenario.params;
 
-            assertThat(params.toString()).isEqualTo(String.join(",", scenario.parameterNameList));
+            assertThat(params).hasToString(String.join(",", scenario.parameterNameList));
         }
 
         @Test

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryValueTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/DefaultQueryValueTest.java
@@ -53,6 +53,6 @@ class DefaultQueryValueTest {
     public void shouldHashCode(){
         ParamQueryValue param = new DefaultQueryValue("name");
         ParamQueryValue paramB = new DefaultQueryValue("name");
-        Assertions.assertThat(param.hashCode()).isEqualTo(paramB.hashCode());
+        Assertions.assertThat(param).hasSameHashCodeAs(paramB);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilderTest.java
@@ -96,6 +96,6 @@ class DefaultConstructorBuilderTest {
         ConstructorBuilder builder = DefaultConstructorBuilder.of(constructor);
         ConstructorBuilder other = DefaultConstructorBuilder.of(constructor);
         assertThat(builder).isEqualTo(other);
-        assertThat(builder.hashCode()).isEqualTo(other.hashCode());
+        assertThat(builder).hasSameHashCodeAs(other);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntityMetadataTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntityMetadataTest.java
@@ -120,7 +120,7 @@ class DefaultEntityMetadataTest {
     public void shouldHashCodeEquals(){
         EntityMetadata entityMetadata = converter.apply(Person.class);
         assertThat(entityMetadata).isEqualTo(converter.apply(Person.class));
-        assertThat(entityMetadata.hashCode()).isEqualTo(entityMetadata.hashCode());
+        assertThat(entityMetadata).hasSameHashCodeAs(entityMetadata);
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultFieldMetadataTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultFieldMetadataTest.java
@@ -49,7 +49,7 @@ class DefaultFieldMetadataTest {
     @Test
     public void shouldEqualsHashCode() {
         assertThat(fieldMetadata).isEqualTo(fieldMetadata);
-        assertThat(fieldMetadata.hashCode()).isEqualTo(fieldMetadata.hashCode());
+        assertThat(fieldMetadata).hasSameHashCodeAs(fieldMetadata);
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultGenericFieldMetaDataTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultGenericFieldMetaDataTest.java
@@ -60,7 +60,7 @@ class DefaultGenericFieldMetaDataTest {
     @Test
     public void shouldEqualsHashCode(){
         Assertions.assertThat(fieldMetadata).isEqualTo(fieldMetadata);
-        Assertions.assertThat(fieldMetadata.hashCode()).isEqualTo(fieldMetadata.hashCode());
+        Assertions.assertThat(fieldMetadata).hasSameHashCodeAs(fieldMetadata);
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/EmbeddedFieldMetadataTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/EmbeddedFieldMetadataTest.java
@@ -48,7 +48,7 @@ class EmbeddedFieldMetadataTest {
     @Test
     public void shouldEqualsHasCode(){
         Assertions.assertThat(metadata).isEqualTo(metadata);
-        Assertions.assertThat(metadata.hashCode()).isEqualTo(metadata.hashCode());
+        Assertions.assertThat(metadata).hasSameHashCodeAs(metadata);
     }
 
 


### PR DESCRIPTION
My change suggestions are about `refact`:

1. AssertJ has specific methods for _hashcode_ and _tostring_, maybe, should be good, use them.

Thank you.