### PR TITLE
fix: resolved recursive call issue

### DIFF
--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -102,8 +102,17 @@ public class CustomRepositoryHandler implements InvocationHandler {
             case OBJECT_METHOD -> {
                 return unwrapInvocationTargetException(() -> unwrapInvocationTargetException(() -> method.invoke(this, params)));
             }
-            case FIND_ALL, FIND_BY, PARAMETER_BASED, CURSOR_PAGINATION -> {
-                return unwrapInvocationTargetException(() -> repository(method).invoke(instance, method, params));
+            case PARAMETER_BASED -> {
+                return unwrapInvocationTargetException(() -> repository(method).executeParameterBased(instance, method, params));
+            }
+            case CURSOR_PAGINATION -> {
+                return unwrapInvocationTargetException(() -> repository(method).executeCursorPagination(instance, method, params));
+            }
+            case FIND_ALL -> {
+                return unwrapInvocationTargetException(() -> repository(method).executeFindAll(instance, method, params));
+            }
+            case FIND_BY -> {
+                return unwrapInvocationTargetException(() -> repository(method).executeFindByQuery(instance, method, params));
             }
             case CUSTOM_REPOSITORY -> {
                 Object customRepository = CDI.current().select(method.getDeclaringClass()).get();


### PR DESCRIPTION
## Changes

- Fixed recursive call issue on CustomRepositoryHandler;

Here is the completed maven log: [mvn.log](https://github.com/user-attachments/files/15538678/mvn.log)

A piece of the maven log that shows the mentioned issue:

``` console
[INFO] Running org.eclipse.jnosql.databases.mongodb.integration.CustomRepositoryIntegrationTest
[ERROR] Tests run: 6, Failures: 0, Errors: 6, Skipped: 0, Time elapsed: 4.824 s <<< FAILURE! -- in org.eclipse.jnosql.databases.mongodb.integration.CustomRepositoryIntegrationTest
[ERROR] org.eclipse.jnosql.databases.mongodb.integration.CustomRepositoryIntegrationTest.shouldDelete -- Time elapsed: 0.925 s <<< ERROR!
java.lang.StackOverflowError
	at java.base/java.lang.StackStreamFactory$AbstractStackWalker.callStackWalk(Native Method)
	at java.base/java.lang.StackStreamFactory$AbstractStackWalker.beginStackWalk(StackStreamFactory.java:424)
	at java.base/java.lang.StackStreamFactory$AbstractStackWalker.walkHelper(StackStreamFactory.java:267)
	at java.base/java.lang.StackStreamFactory$AbstractStackWalker.walk(StackStreamFactory.java:259)
	at java.base/java.lang.StackWalker.walk(StackWalker.java:543)
	at java.logging/java.util.logging.LogRecord$CallerFinder.get(LogRecord.java:784)
	at java.logging/java.util.logging.LogRecord.inferCaller(LogRecord.java:757)
	at java.logging/java.util.logging.LogRecord.getSourceClassName(LogRecord.java:351)
	at java.logging/java.util.logging.SimpleFormatter.format(SimpleFormatter.java:163)
	at java.logging/java.util.logging.StreamHandler.publish0(StreamHandler.java:241)
	at java.logging/java.util.logging.StreamHandler.publish(StreamHandler.java:224)
	at java.logging/java.util.logging.ConsoleHandler.publish(ConsoleHandler.java:95)
	at java.logging/java.util.logging.Logger.log(Logger.java:983)
	at java.logging/java.util.logging.Logger.doLog(Logger.java:1010)
	at java.logging/java.util.logging.Logger.log(Logger.java:1033)
	at java.logging/java.util.logging.Logger.info(Logger.java:1806)
	at org.eclipse.jnosql.mapping.semistructured.query.CustomRepositoryHandler.invoke(CustomRepositoryHandler.java:84)
	at jdk.proxy2/jdk.proxy2.$Proxy133.getById(Unknown Source)
....
``` 
