### PR TITLE
minor error message fix

### DIFF
--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/DefaultValue.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/DefaultValue.java
@@ -54,7 +54,7 @@ record DefaultValue(Object value)  implements Value {
         if (REFERENCE_READER.test(Objects.requireNonNull(supplier, "supplier is required"))) {
             return REFERENCE_READER.convert(supplier, value);
         }
-        throw new UnsupportedOperationException("The type " + supplier + " is not supported");
+        throw new UnsupportedOperationException("The type " + supplier.get().getTypeName() + " is not supported");
     }
 
     @Override

--- a/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/DefaultValueTest.java
+++ b/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/DefaultValueTest.java
@@ -163,7 +163,7 @@ class DefaultValueTest {
             Map<String, List<String>> result = value.get(new TypeReference<>() {
             });
         }).isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("The type TypeReference{type=java.util.Map<java.lang.String, java.util.List<java.lang.String>>} is not supported");
+                .hasMessage("The type java.util.Map<java.lang.String, java.util.List<java.lang.String>> is not supported");
     }
 
     @Test


### PR DESCRIPTION
The error message should contain the type and not a supplier object.

It took me some time to figure out what was wrong with my code with a message like:
>The type org.eclipse.jnosql.mapping.reflection.ReflectionClassConverter$$Lambda$1081/0x00000208cea01230@24584a22 is not supported

Cheers,

D.