### PR TITLE
refactor: update provider name to be more compatible with Jakarta Config

### DIFF
--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilter.java
@@ -33,7 +33,7 @@ enum RepositoryFilter implements Predicate<Class<?>> {
 
     INSTANCE;
 
-    private static final String PROVIDER = "Eclipse JNoSQL"; //TODO move this to a public location accessible to users
+    private static final String PROVIDER = "Eclipse_JNoSQL"; //TODO move this to a public location accessible to users
 
     @Override
     public boolean test(Class<?> type) {

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
@@ -60,7 +60,7 @@ class ClassGraphClassScannerTest {
 
         assertThat(reepositores).hasSize(4)
                 .contains(Persons.class,
-                		AnimalRepository.class,
+                        AnimalRepository.class,
                         PersonRepository.class,
                         MovieRepository.class);
     }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilterTest.java
@@ -20,9 +20,6 @@ import jakarta.nosql.Id;
 import org.eclipse.jnosql.mapping.reflection.entities.NoSQLVendor;
 import org.eclipse.jnosql.mapping.reflection.entities.Person;
 import org.eclipse.jnosql.mapping.reflection.entities.PersonRepository;
-import org.eclipse.jnosql.mapping.reflection.entities.NoSQLVendor;
-import org.eclipse.jnosql.mapping.reflection.entities.Person;
-import org.eclipse.jnosql.mapping.reflection.entities.PersonRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -102,7 +99,7 @@ class RepositoryFilterTest {
     public interface Persons extends BasicRepository<Person, Long> {
     }
 	
-    @jakarta.data.repository.Repository(provider = "Eclipse JNoSQL")
+    @jakarta.data.repository.Repository(provider = "Eclipse_JNoSQL")
     private interface Server extends BasicRepository<Computer, String> {
     }
 


### PR DESCRIPTION
Upon doing a retrospective on #559 it was pointed out to me that if Jakarta Config is accepted into Jakarta EE 12 then using the `@Repository` provider attribute of `Eclipse JNoSQL` might be problematic if that attribute is configurable using Jakarta Config.  If Jakarta Config follows the Microprofile Spec the space should not be an issue, but we could avoid potential issues by transitioning to `Eclipse_JNoSQL` or something without a space.

I'm also open to suggestions. 